### PR TITLE
Pass modules deps to wrap method

### DIFF
--- a/lib/bemhtml/compiler.js
+++ b/lib/bemhtml/compiler.js
@@ -627,7 +627,14 @@ Compiler.prototype.wrap = function wrap(code) {
   if (!this.options.wrap)
     return code;
 
-  var exportName = this.options.exportName || 'BEMHTML';
+  var opts = this.options;
+  var exportName = opts.exportName || 'BEMHTML';
+  var deps = opts.modulesDeps;
+  var modulesDeps = deps ? ', ' + JSON.stringify(Object.keys(deps)) : '';
+  var modulesProvidedDeps =  deps ? ', ' + Object.keys(deps).map(function(module) {
+    var providedName = deps[module];
+    return providedName === true ? module : providedName;
+  }).join(', ') : '';
 
   return '(function(g) {\n' +
          '  var __bem_xjst = (function(exports) {\n' +
@@ -640,8 +647,8 @@ Compiler.prototype.wrap = function wrap(code) {
          '    defineAsGlobal = false;\n' +
          '  }\n' +
          '  if(typeof modules === "object") {\n' +
-         '    modules.define("' + exportName + '",\n' +
-         '                   function(provide) { provide(__bem_xjst) });\n' +
+         '    modules.define("' + exportName + '"' + modulesDeps + ',\n' +
+         '                   function(provide' + modulesProvidedDeps + ') { provide(__bem_xjst) });\n' +
          '    defineAsGlobal = false;\n' +
          '  }\n' +
          '  defineAsGlobal && (g["' + exportName + '"] = __bem_xjst);\n' +


### PR DESCRIPTION
BEMTREE expects to have `vow` module as `Vow` variable so we need possibility to pass both names separately.

The way to use this API in techs:

``` js
return BEMHTML.generate(sources, {
    wrap : true,
    exportName : exportName,
    optimize : optimize,
    cache   : optimize && process.env[exportName + '_CACHE'] === 'on',
    modulesDeps : this.getModulesDeps() // { vow: 'Vow' }
});
```

// cc @veged @indutny 
