### PR TITLE
Fix modules deps in wrap method

### DIFF
--- a/lib/bemhtml/compiler.js
+++ b/lib/bemhtml/compiler.js
@@ -637,21 +637,22 @@ Compiler.prototype.wrap = function wrap(code) {
   }).join(', ') : '';
 
   return '(function(g) {\n' +
-         '  var __bem_xjst = (function(exports) {\n' +
+         '  var __bem_xjst = function(exports' + modulesProvidedDeps + ') {\n' +
          '     ' + code + ';\n' +
          '     return exports;\n' +
-         '  })({});\n' +
+         '  }\n' +
          '  var defineAsGlobal = true;\n' +
          '  if(typeof exports === "object") {\n' +
-         '    exports["' + exportName + '"] = __bem_xjst;\n' +
+         '    exports["' + exportName + '"] = __bem_xjst({});\n' +
          '    defineAsGlobal = false;\n' +
          '  }\n' +
          '  if(typeof modules === "object") {\n' +
          '    modules.define("' + exportName + '"' + modulesDeps + ',\n' +
-         '                   function(provide' + modulesProvidedDeps + ') { provide(__bem_xjst) });\n' +
+         '      function(provide' + modulesProvidedDeps + ') {\n' +
+         '        provide(__bem_xjst({}' + modulesProvidedDeps + ')) });\n' +
          '    defineAsGlobal = false;\n' +
          '  }\n' +
-         '  defineAsGlobal && (g["' + exportName + '"] = __bem_xjst);\n' +
+         '  defineAsGlobal && (g["' + exportName + '"] = __bem_xjst({}));\n' +
          '})(this);'
 };
 


### PR DESCRIPTION
I'm loshara. Adding `vow` to `modules.define('BEMTREE')` in https://github.com/bem/bem-xjst/pull/15 was not enough 'cos at the time we define `BEMTREE` module, the function which returns object we need to provide is already executed.

This is the fix.

// cc @veged @indutny 
