### PR TITLE
runtime: adapt to the faster dev mode in xjst

### DIFF
--- a/lib/bemhtml/compiler.js
+++ b/lib/bemhtml/compiler.js
@@ -772,8 +772,7 @@ Compiler.prototype.generate = function generate(code) {
                  code + ';\n' +
                  '/// -------------------------------------\n' +
                  '/// ------ BEM-XJST User-code End -------\n' +
-                 '/// -------------------------------------\n' +
-                 '__$flush();\n';
+                 '/// -------------------------------------\n';
     return this.wrap(xjst.generate(source, this.options));
   }
 

--- a/lib/bemhtml/runtime.js
+++ b/lib/bemhtml/runtime.js
@@ -1,43 +1,43 @@
 module.exports = function() {
+  "xjst: no reverse";
   var __$that = this,
       __$blockRef = {},
       __$elemRef = {},
-      __$queue = [];
+      __$depth = 0;
 
   // Called after all matches
-  function __$flush() {
-    __$queue.filter(function(item) {
-      return !item.__$parent;
-    }).forEach(function(item) {
-      function apply(conditions, item) {
-        if (item && item.__$children) {
-          // Sub-template
-          var subcond = conditions.concat(item.__$cond);
-          item.__$children.forEach(function(child) {
-            apply(subcond, child);
-          });
-        } else {
-          var hasBlock = false;
-          var hasElem = false;
-          conditions = conditions.filter(function(cond) {
-            if (cond === __$blockRef) {
-              hasBlock = true;
-              return false;
-            }
-            if (cond === __$elemRef) {
-              hasElem = true;
-              return false;
-            }
-            return true;
-          });
-          if (hasBlock && !hasElem) conditions.push(!__$that.elem);
+  function __$flush(item) {
+    function apply(conditions, item) {
+      if (item && item.__$children) {
+        // Sub-template
+        var subcond = conditions.concat(item.__$cond);
 
-          // Body
-          template.apply(null, conditions)(item);
-        }
+        // Reverse order
+        for (var i = item.__$children.length - 1; i >= 0; i--)
+          apply(subcond, item.__$children[i]);
+      } else {
+        var hasBlock = false;
+        var hasElem = false;
+        conditions = conditions.filter(function(cond) {
+          if (cond === __$blockRef) {
+            hasBlock = true;
+            return false;
+          }
+          if (cond === __$elemRef) {
+            hasElem = true;
+            return false;
+          }
+          return true;
+        });
+        if (hasBlock && !hasElem) conditions.push(!__$that.elem);
+
+        // Body
+        template.apply(null, conditions)(item);
       }
-      apply([], item);
-    });
+    }
+
+    __$depth = 0;
+    apply([], item);
   };
 
   // Matching
@@ -46,19 +46,27 @@ module.exports = function() {
       var args = Array.prototype.slice.call(arguments);
 
       args.forEach(function(arg) {
-        if (arg && arg.__$children) {
-          // Sub-template
-          arg.__$parent = fn;
-        }
         fn.__$children.push(arg);
+
+        if (!arg)
+          return;
+
+        // Sub-template
+        if (arg.__$children)
+          arg.__$parent = fn;
       });
 
       // Handle match().match()
       var res = fn;
       while (res.__$parent) res = res.__$parent;
+
+      if (res.__$depth === 0) {
+        __$flush(res);
+      }
+
       return res;
     };
-    __$queue.push(fn);
+    fn.__$depth = __$depth++;
     fn.__$children = [];
     fn.__$parent = null;
     fn.__$cond = Array.prototype.slice.call(arguments);
@@ -189,4 +197,5 @@ module.exports = function() {
     var rest = Array.prototype.slice.call(arguments, 0, -1);
     return applyNext.apply(this, [{ _mode: '', ctx: context }].concat(rest));
   };
+  "xjst: end no reverse";
 }.toString().replace(/^function\s*\(\)\s*{|}$/g, '');

--- a/lib/bemhtml/runtime.js
+++ b/lib/bemhtml/runtime.js
@@ -3,104 +3,109 @@ module.exports = function() {
   var __$that = this,
       __$blockRef = {},
       __$elemRef = {},
-      __$depth = 0;
+      __$queue = [];
 
   // Called after all matches
-  function __$flush(item) {
-    function apply(conditions, item) {
-      if (item && item.__$children) {
-        // Sub-template
-        var subcond = conditions.concat(item.__$cond);
+  function __$flush(conditions, item) {
+    if (item.children.length > 0) {
+      // Sub-template
+      var subcond = conditions.concat(item.args);
 
-        // Reverse order
-        for (var i = item.__$children.length - 1; i >= 0; i--)
-          apply(subcond, item.__$children[i]);
-      } else {
-        var hasBlock = false;
-        var hasElem = false;
-        conditions = conditions.filter(function(cond) {
-          if (cond === __$blockRef) {
-            hasBlock = true;
-            return false;
-          }
-          if (cond === __$elemRef) {
-            hasElem = true;
-            return false;
-          }
-          return true;
-        });
-        if (hasBlock && !hasElem) conditions.push(!__$that.elem);
-
-        // Body
-        template.apply(null, conditions)(item);
+      // Reverse order
+      for (var i = item.children.length - 1; i >= 0; i--)
+        __$flush(subcond, item.children[i]);
+    } else {
+      var hasBlock = false;
+      var hasElem = false;
+      var filtered = [];
+      for (var i = 0; i < conditions.length; i++) {
+        var cond = conditions[i];
+        if (cond === __$blockRef) {
+          hasBlock = true;
+          continue;
+        }
+        if (cond === __$elemRef) {
+          hasElem = true;
+          continue;
+        }
+        filtered.push(cond);
       }
-    }
+      if (hasBlock && !hasElem) filtered.push(!__$that.elem);
 
-    __$depth = 0;
-    apply([], item);
+      // Body
+      template.apply(null, filtered)(item.args[0]);
+    }
   };
 
-  // Matching
+  function $$Predicates(args) {
+    this.args = args;
+    this.children = [];
+
+    for (var i = args.length - 1; i >= 0; i--) {
+      var arg = args[i];
+      if (arg !== $$bodyMatch)
+        continue;
+
+      args[i] = __$queue.pop();
+    }
+
+    for (var i = 0; i < args.length; i++) {
+      if (!(args[i] instanceof $$Predicates))
+        continue;
+
+      var arg = args[i];
+      args.splice(i, 1);
+      i--;
+      this.children.push(arg);
+    }
+  }
+
+  function $$bodyMatch() {
+    var args = new Array(arguments.length);
+    for (var i = 0; i < arguments.length; i++)
+      args[i] = arguments[i];
+
+    var child = new $$Predicates(args);
+    __$queue[__$queue.length - 1].children.push(child);
+
+    if (__$queue.length === 1)
+      __$flush([], __$queue.shift());
+
+    return $$bodyMatch;
+  }
+
   function match() {
-    function fn() {
-      var args = Array.prototype.slice.call(arguments);
+    var args = new Array(arguments.length);
+    for (var i = 0; i < arguments.length; i++)
+      args[i] = arguments[i];
 
-      args.forEach(function(arg) {
-        fn.__$children.push(arg);
+    __$queue.push(new $$Predicates(args));
 
-        if (!arg)
-          return;
+    return $$bodyMatch;
+  }
 
-        // Sub-template
-        if (arg.__$children)
-          arg.__$parent = fn;
-      });
-
-      // Handle match().match()
-      var res = fn;
-      while (res.__$parent) res = res.__$parent;
-
-      if (res.__$depth === 0) {
-        __$flush(res);
-      }
-
-      return res;
-    };
-    fn.__$depth = __$depth++;
-    fn.__$children = [];
-    fn.__$parent = null;
-    fn.__$cond = Array.prototype.slice.call(arguments);
-
-    fn.match = match;
-    fn.elemMatch = elemMatch;
-    fn.block = block;
-    fn.elem = elem;
-    fn.mode = mode;
-    fn.mod = mod;
-    fn.elemMod = elemMod;
-    fn.def = def;
-    fn.tag = tag;
-    fn.attrs = attrs;
-    fn.cls = cls;
-    fn.js = js;
-    fn.jsAttr = jsAttr;
-    fn.bem = bem;
-    fn.mix = mix;
-    fn.content = content;
-    fn.replace = replace;
-    fn.extend = extend;
-
-    // match().match()
-    if (this && this.__$children) {
-      this.__$children.push(fn);
-      fn.__$parent = this;
-    }
-
-    return fn;
-  };
+  var __$methods = [
+    match, elemMatch, block, elem, mode, mod,
+    elemMod, def, tag, attrs, cls, js, jsAttr,
+    bem, mix, content, replace, extend
+  ];
+  function $$setMethods(fn) {
+    __$methods.forEach(function(method) {
+      fn[method.name] = function methodWrap() {
+        var res = method.apply(this, arguments);
+        var child = __$queue.pop();
+        var last = __$queue[__$queue.length - 1];
+        last.args = last.args.concat(child.args);
+        last.children = last.children.concat(child.children);
+        return res;
+      };
+    });
+  }
+  $$setMethods(match);
+  $$setMethods($$bodyMatch);
 
   function block(name) {
-    return match.call(this, __$blockRef, __$that.block === name);
+    return match(__$blockRef, __$that.block === name, 'block ' + name);
   };
 
   function elemMatch() {
@@ -109,44 +114,44 @@ module.exports = function() {
   }
 
   function elem(name) {
-    return match.call(this, __$elemRef, __$that.elem === name);
+    return match(__$elemRef, __$that.elem === name, 'elem ' + name);
   };
 
   function mode(name) {
-    return match.call(this, __$that._mode === name);
+    return match(__$that._mode === name, 'mode ' + name);
   };
 
   function mod(name, value) {
-    return match.call(this, __$that.mods, function() {
+    return match(__$that.mods, function() {
       return __$that.mods[name] === value;
     });
   }
 
   function elemMod(name, value) {
-    return match.call(this, __$that.elemMods, function() {
+    return match(__$that.elemMods, function() {
       return __$that.elemMods[name] === value;
     });
   }
 
-  function def() { return mode.call(this, 'default'); };
-  function tag() { return mode.call(this, 'tag'); };
-  function attrs() { return mode.call(this,'attrs'); };
-  function cls() { return mode.call(this, 'cls'); };
-  function js() { return mode.call(this, 'js'); };
-  function jsAttr() { return mode.call(this, 'jsAttr'); };
-  function bem() { return mode.call(this, 'bem'); };
-  function mix() { return mode.call(this, 'mix'); };
-  function content() { return mode.call(this, 'content'); };
+  function def() { return mode('default'); };
+  function tag() { return mode('tag'); };
+  function attrs() { return mode('attrs'); };
+  function cls() { return mode('cls'); };
+  function js() { return mode('js'); };
+  function jsAttr() { return mode('jsAttr'); };
+  function bem() { return mode('bem'); };
+  function mix() { return mode('mix'); };
+  function content() { return mode('content'); };
   function replace() {
-    var self = this;
+    var adaptor = def();
     return function (body) {
-      return self.def()(function () { return applyCtx(body()) });
+      return adaptor(function () { return applyCtx(body()) });
     };
   };
   function extend() {
-    var self = this;
+    var adaptor = def();
     return function (body) {
-      return self.def()(function () {
+      return adaptor(function () {
         return applyCtx(this.extend(this.ctx, body()));
       });
     };


### PR DESCRIPTION
xjst is now reversing the statements in a dev mode, adapt to these
changes and make sure to run the templates in a correct order.

See: https://github.com/veged/xjst/pull/43