### PR TITLE
tree: verify `.match()` arguments

### DIFF
--- a/bin/bem-xjst
+++ b/bin/bem-xjst
@@ -51,7 +51,9 @@ require('coa').Cmd()
       options.input.resume();
 
       function finish(source) {
-        var out = bem_xjst.generate(source, options);
+        var out = bem_xjst.generate(source, {
+          'no-opt': options['no-opt']
+        });
 
         options.output.write(out);
 

--- a/lib/bemhtml/runtime/tree.js
+++ b/lib/bemhtml/runtime/tree.js
@@ -1,3 +1,4 @@
+var assert = require('minimalistic-assert');
 var inherits = require('inherits');
 
 function Template(predicates, body) {
@@ -291,6 +292,7 @@ Tree.prototype.match = function match() {
     var arg = arguments[i];
     if (typeof arg === 'function')
       arg = new CustomMatch(arg);
+    assert(arg instanceof MatchBase, 'Wrong .match() argument');
     children[i] = arg;
   }
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "coa": "~0.3.9",
     "inherits": "^2.0.1",
+    "minimalistic-assert": "^1.0.0",
     "q": "~0.9.3"
   },
   "devDependencies": {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -34,9 +34,8 @@ function test(fn, data, expected, options) {
 exports.test = test;
 
 function fail(fn, regexp) {
-  var body = fn2str(fn);
   assert.throws(function() {
-    bemxjst.compile(body);
+    bemxjst.compile(fn);
   }, regexp);
 }
 exports.fail = fail;

--- a/test/tree-test.js
+++ b/test/tree-test.js
@@ -1,6 +1,7 @@
 var fixtures = require('./fixtures');
 
 var test = fixtures.test;
+var fail = fixtures.fail;
 
 describe('BEMHTML compiler/Tree', function() {
   it('should compile example code', function() {
@@ -304,5 +305,11 @@ describe('BEMHTML compiler/Tree', function() {
     }, {
       block: 'b1'
     }, '<div class="b1">ok</div>');
+  });
+
+  it('should verify match() argument', function() {
+    fail(function() {
+      block('b1').match('123')('123');
+    }, /Wrong.*match.*argument/);
   });
 });


### PR DESCRIPTION
Fix: #106 

cc @tadatuta 