### PR TITLE
Support attrs values as an object

### DIFF
--- a/lib/bemhtml/runtime/index.js
+++ b/lib/bemhtml/runtime/index.js
@@ -507,11 +507,10 @@ BEMHTML.prototype.renderClose = function renderClose(prefix,
       if (attr === undefined)
         continue;
 
-      // TODO(indutny): support `this.reapply()`
       out += ' ' + name + '="' +
         utils.attrEscape(utils.isSimple(attr) ?
                          attr :
-                         this.reapply(attr)) +
+                         this.context.reapply(attr)) +
                          '"';
     }
   }

--- a/test/runtime-test.js
+++ b/test/runtime-test.js
@@ -209,6 +209,16 @@ describe('BEMHTML compiler/Runtime', function() {
     }, { block: 'b1' }, '<div class="b1"><div class="b2">ok</div></div>');
   });
 
+  it('should support objects as attrs values', function() {
+    test(function() {
+      block('b1').attrs()(function() {
+        return { prop1: { block: 'b2' } };
+      });
+
+      block('b2').replace()('hello');
+    }, { block: 'b1' }, '<div class="b1" prop1="hello"></div>');
+  });
+
   describe('mods', function() {
     it('should lazily define mods', function() {
       test(function() {


### PR DESCRIPTION
Closes #124

WARNING! Looks like bem-xjst 1.x results with `some-attr=[object Object]` for `attrs()({ 'some-attr': { block: 'b1' } })` (see expected section of #124) which I think is also wrong.

cc @indutny @veged @blond 