### PR TITLE
Throw error if args passed to shortcut predicates

### DIFF
--- a/bench/package.json
+++ b/bench/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "bem-xjst": "git+ssh://github.com/bem/bem-xjst.git#505f579",
+    "bem-xjst": "git+ssh://github.com/bem/bem-xjst.git#4397ed7",
     "benchmark": "^1.0.0",
     "browserify": "^11.0.0",
     "microtime": "^1.4.2",

--- a/lib/bemhtml/runtime/tree.js
+++ b/lib/bemhtml/runtime/tree.js
@@ -302,11 +302,17 @@ Tree.prototype.match = function match() {
 };
 
 Tree.prototype.once = function once() {
+  if (arguments.length) throw new Error('Predicate should not have arguments');
   return this.match(new OnceMatch());
 };
 
+Tree.prototype.applyMode = function applyMode(args, mode) {
+  if (args.length) throw new Error('Predicate should not have arguments');
+  return this.mode(mode);
+};
+
 Tree.prototype.wrap = function wrap() {
-  return this.def().match(new WrapMatch(this.refs));
+  return this.def.apply(this, arguments).match(new WrapMatch(this.refs));
 };
 
 Tree.prototype.xjstOptions = function xjstOptions(options) {
@@ -340,22 +346,48 @@ Tree.prototype.elemMod = function elemMod(name, value) {
   return this.match(new PropertyMatch([ 'elemMods', name ], value));
 };
 
-Tree.prototype.def = function def() { return this.mode('default'); };
-Tree.prototype.tag = function tag() { return this.mode('tag'); };
-Tree.prototype.attrs = function attrs() { return this.mode('attrs'); };
-Tree.prototype.cls = function cls() { return this.mode('cls'); };
-Tree.prototype.js = function js() { return this.mode('js'); };
-Tree.prototype.jsAttr = function jsAttr() { return this.mode('jsAttr'); };
-Tree.prototype.bem = function bem() { return this.mode('bem'); };
-Tree.prototype.mix = function mix() { return this.mode('mix'); };
-Tree.prototype.content = function content() { return this.mode('content'); };
+Tree.prototype.def = function def() {
+  return this.applyMode(arguments, 'default');
+};
+
+Tree.prototype.tag = function tag() {
+  return this.applyMode(arguments, 'tag');
+};
+
+Tree.prototype.attrs = function attrs() {
+  return this.applyMode(arguments, 'attrs');
+};
+
+Tree.prototype.cls = function cls() {
+  return this.applyMode(arguments, 'cls');
+};
+
+Tree.prototype.js = function js() {
+  return this.applyMode(arguments, 'js');
+};
+
+Tree.prototype.jsAttr = function jsAttr() {
+  return this.applyMode(arguments, 'jsAttr');
+};
+
+Tree.prototype.bem = function bem() {
+  return this.applyMode(arguments, 'bem');
+};
+
+Tree.prototype.mix = function mix() {
+  return this.applyMode(arguments, 'mix');
+};
+
+Tree.prototype.content = function content() {
+  return this.applyMode(arguments, 'content');
+};
 
 Tree.prototype.replace = function replace() {
-  return this.def().match(new ReplaceMatch(this.refs));
+  return this.def.apply(this, arguments).match(new ReplaceMatch(this.refs));
 };
 
 Tree.prototype.extend = function extend() {
-  return this.def().match(new ExtendMatch(this.refs));
+  return this.def.apply(this, arguments).match(new ExtendMatch(this.refs));
 };
 
 Tree.prototype.oninit = function oninit(fn) {

--- a/test/runtime-test.js
+++ b/test/runtime-test.js
@@ -192,7 +192,7 @@ describe('BEMHTML compiler/Runtime', function() {
         return { elem: 'e1' };
       });
 
-      block('b1').elem('e1').mod('a', 'b').tag('span');
+      block('b1').elem('e1').mod('a', 'b').tag()('span');
     }, { block: 'b1' }, '<div class="b1"><div class="b1__e1"></div></div>');
   });
 
@@ -917,6 +917,112 @@ describe('BEMHTML compiler/Runtime', function() {
     it('should throw error with one apply', function() {
       assert.throws(function() {
         template.apply(bemjson);
+      });
+    });
+
+    it('should throw error when args passed to def mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').def('blah');
+        });
+      });
+    });
+
+    it('should throw error when args passed to attrs mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').attrs('blah');
+        });
+      });
+    });
+
+    it('should throw error when args passed to cls mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').cls('blah');
+        });
+      });
+    });
+
+    it('should throw error when args passed to js mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').js('blah');
+        });
+      });
+    });
+
+    it('should throw error when args passed to jsAttr mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').jsAttr('blah');
+        });
+      });
+    });
+
+    it('should throw error when args passed to bem mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').bem('blah');
+        });
+      });
+    });
+
+    it('should throw error when args passed to replace mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').replace('blah');
+        });
+      });
+    });
+
+    it('should throw error when args passed to extend mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').extend('blah');
+        });
+      });
+    });
+
+    it('should throw error when args passed to wrap mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').wrap('blah');
+        });
+      });
+    });
+
+    it('should throw error when args passed to once mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').once('blah');
+        });
+      });
+    });
+
+    it('should throw error when args passed to content mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').content('blah');
+        });
+      });
+    });
+
+    it('should throw error when args passed to mix mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').mix([
+            { block: 'b2' }
+          ]);
+        });
+      });
+    });
+
+    it('should throw error when args passed to tag mode', function() {
+      assert.throws(function() {
+        bemxjst.compile(function() {
+          block('b1').tag('span');
+        });
       });
     });
 


### PR DESCRIPTION
Related to #49 

tadatuta@tadatuta-osx:~/Sites/bem-xjst-new/bench$ node run.js --compare
render:basic:next x 582,915 ops/sec ±1.07% (86 runs sampled)
render:basic:prev x 627,541 ops/sec ±0.98% (83 runs sampled)
render:islands:next x 984 ops/sec ±1.37% (85 runs sampled)
render:islands:prev x 963 ops/sec ±1.50% (84 runs sampled)
render:showcase:next x 1,912 ops/sec ±1.23% (86 runs sampled)
render:showcase:prev x 1,853 ops/sec ±1.09% (86 runs sampled)

tadatuta@tadatuta-osx:~/Sites/bem-xjst-new/bench$ node run.js --compare
render:basic:next x 645,760 ops/sec ±1.58% (86 runs sampled)
render:basic:prev x 658,075 ops/sec ±1.61% (85 runs sampled)
render:islands:next x 922 ops/sec ±1.02% (85 runs sampled)
render:islands:prev x 917 ops/sec ±1.37% (83 runs sampled)
render:showcase:next x 1,786 ops/sec ±1.16% (86 runs sampled)
render:showcase:prev x 1,811 ops/sec ±1.30% (85 runs sampled)

tadatuta@tadatuta-osx:~/Sites/bem-xjst-new/bench$ node run.js --compare
render:basic:next x 648,840 ops/sec ±1.17% (85 runs sampled)
render:basic:prev x 629,380 ops/sec ±1.45% (85 runs sampled)
render:islands:next x 896 ops/sec ±1.56% (85 runs sampled)
render:islands:prev x 955 ops/sec ±1.39% (85 runs sampled)
render:showcase:next x 1,798 ops/sec ±1.40% (85 runs sampled)
render:showcase:prev x 1,766 ops/sec ±1.42% (85 runs sampled)

cc @veged @indutny 