### PR TITLE
bemxjst: fix order of execution of `match`es

### DIFF
--- a/lib/bemxjst/match.js
+++ b/lib/bemxjst/match.js
@@ -107,11 +107,8 @@ function MatchTemplate(mode, template) {
   }
 
   // Insert late predicates
-  for (var i = postpone.length - 1; i >= 0; i--)
-    this.predicates[i + j] = this.predicates[i];
-  for (var i = 0; i < postpone.length; i++)
-    this.predicates[i] = postpone[i];
-  j += postpone.length;
+  for (var i = 0; i < postpone.length; i++, j++)
+    this.predicates[j] = postpone[i];
 
   if (this.predicates.length !== j)
     this.predicates.length = j;
@@ -186,7 +183,7 @@ Match.prototype.exec = function exec(context) {
   for (var i = 0; i < this.count; i++) {
     if ((mask & bit) === 0) {
       template = this.templates[i];
-      for (var j = template.predicates.length - 1; j >= 0; j--) {
+      for (var j = 0; j < template.predicates.length; j++) {
         var pred = template.predicates[j];
 
         /* jshint maxdepth : false */
@@ -195,7 +192,7 @@ Match.prototype.exec = function exec(context) {
       }
 
       // All predicates matched!
-      if (j === -1)
+      if (j === template.predicates.length)
         break;
     }
 

--- a/test/bemhtml/tree-test.js
+++ b/test/bemhtml/tree-test.js
@@ -312,4 +312,22 @@ describe('BEMHTML compiler/Tree', function() {
       block('b1').match('123')('123');
     }, /Wrong.*match.*argument/);
   });
+
+  it('should execute matches in right order', function() {
+    test(function() {
+      block('bla')(
+        tag()('span'),
+        // this.ctx.d is undefined
+        match(function() { return this.ctx.d; })(
+          tag()('a'),
+          attrs()(match(function() { return this.ctx.d.a; })(function() {
+            // this will throw error
+            return { f: 1 };
+          }))
+        )
+      );
+    }, {
+      block: 'bla'
+    }, '<span class="bla"></span>');
+  });
 });


### PR DESCRIPTION
Always execute matches in the same order as they came in the input file.

Fix: #146