### PR TITLE
Improved mix behaviour

### DIFF
--- a/lib/bemhtml/index.js
+++ b/lib/bemhtml/index.js
@@ -213,7 +213,15 @@ BEMHTML.prototype.renderMix = function renderMix(entity,
     if (typeof item === 'string')
       item = { block: item, elem: undefined };
 
-    var hasItem = item.block || item.elem;
+    var hasItem = false;
+
+    if (item.elem) {
+      hasItem = item.elem !== entity.elem && item.elem !== context.elem;
+    } else if (item.block) {
+      hasItem = !(item.block === entity.block && item.mods) ||
+        item.mods && entity.elem;
+    }
+
     var block = item.block || item._block || context.block;
     var elem = item.elem || item._elem || context.elem;
     var key = classBuilder.build(block, elem);
@@ -225,7 +233,8 @@ BEMHTML.prototype.renderMix = function renderMix(entity,
       out += ' ' + classBuilder.build(block, classElem);
 
     out += this.buildModsClasses(block, classElem,
-      elem ? item.elemMods : item.mods);
+      (item.elem || !item.block && (item._elem || context.elem)) ?
+        item.elemMods : item.mods);
 
     if (item.js) {
       if (!js)

--- a/test/bemjson-mix-test.js
+++ b/test/bemjson-mix-test.js
@@ -2,16 +2,6 @@ var fixtures = require('./fixtures')('bemhtml');
 var test = fixtures.test;
 
 describe('BEMJSON mix', function() {
-  it('should return mix', function() {
-    test(function() {
-      block('button').def()(function() {
-        return JSON.stringify(this.ctx.mix);
-      });
-    },
-    { block: 'button', mix: { block: 'mix' } },
-    '{"block":"mix"}');
-  });
-
   it('should support mix in json', function() {
     test(function() {},
     {
@@ -19,16 +9,6 @@ describe('BEMJSON mix', function() {
       mix: { block: 'b2' }
     },
     '<div class="b1 b2"></div>');
-  });
-
-  it('should mix with block itself', function() {
-    test(function() { },
-    {
-      block: 'b1',
-      elem: 'e1',
-      mix: { block: 'b1' }
-    },
-    '<div class="b1__e1 b1"></div>');
   });
 
   it('should not propagate parent elem to JS params', function() {
@@ -39,5 +19,223 @@ describe('BEMJSON mix', function() {
       mix: { block: 'b2', js: true }
     },
     '<div class="b1__e1 b2 i-bem" data-bem=\'{"b2":{}}\'></div>');
+  });
+
+  describe('the same block', function() {
+    // Weird case, but for completeness why not to check it.
+    // Because we don’t know about difference of entity.block
+    // and context.block. See next test.
+    it('should duplicate block class if mix block to itself', function() {
+      test(function() {},
+      {
+        block: 'b',
+        mix: { block: 'b' }
+      },
+      '<div class="b b"></div>');
+    });
+
+    it('should mix with block itself to elem in block', function() {
+      test(function() {},
+      {
+        block: 'b1',
+        content: {
+          elem: 'e1',
+          mix: { block: 'b1' }
+        }
+      },
+      '<div class="b1"><div class="b1__e1 b1"></div></div>');
+    });
+
+    it('should mix block to the same block’s elem', function() {
+      test(function() {},
+      {
+        block: 'b1',
+        elem: 'e1',
+        mix: { block: 'b1' }
+      },
+      '<div class="b1__e1 b1"></div>');
+    });
+
+    it('should not duplicate block class ' +
+      'if mix mods without block to the same block',
+      function() {
+      test(function() {},
+      {
+        block: 'b',
+        mix: { mods: { m: 'v' } }
+      },
+      '<div class="b b_m_v"></div>');
+    });
+  });
+
+  describe('the same block with mods', function() {
+    it('should mix block with mods to elem in the same block',
+      function() {
+      test(function() {},
+      {
+        block: 'b',
+        content: {
+          elem: 'e',
+          mix: { block: 'b', mods: { m: 'v' } }
+        }
+      },
+      '<div class="b"><div class="b__e b b_m_v"></div></div>');
+    });
+
+    it('should duplicate block class ' +
+      'if mix several block with mods to elem in the same block',
+      function() {
+      test(function() {},
+      {
+        block: 'b',
+        content: {
+          elem: 'e',
+          mix: [
+            { block: 'b', mods: { m1: 'v1' } },
+            { block: 'b', mods: { m2: 'v2' } }
+          ]
+        }
+      },
+      '<div class="b"><div class="b__e b b_m1_v1 b b_m2_v2"></div></div>');
+    });
+
+    it('should not duplicate block class if mix mods without block ' +
+      'to the same block with mods',
+      function() {
+      test(function() {},
+      {
+        block: 'b',
+        mods: { m1: 'v1' },
+        mix: { mods: { m2: 'v2' } }
+      },
+      '<div class="b b_m1_v1 b_m2_v2"></div>');
+    });
+
+    it('should duplicate mix mods class if mix the same block with mods',
+      // Because developer should not want to do this
+      // we’ll not check this case.
+      function() {
+      test(function() {},
+      {
+        block: 'b',
+        mods: { m: 'v' },
+        mix: { mods: { m: 'v' } }
+      },
+      '<div class="b b_m_v b_m_v"></div>');
+    });
+
+    it('should not duplicate block class if mix is the same block with mods',
+      function() {
+      test(function() {},
+      {
+        block: 'b',
+        mix: [
+          { block: 'b', mods: { m1: 'v1' } },
+          { block: 'b', mods: { m2: 'v2' } }
+        ]
+      },
+      '<div class="b b_m1_v1 b_m2_v2"></div>');
+    });
+
+    it('should duplicate block mods class if mix is the same block with mods',
+      function() {
+      // Because who cares? It’s pretty rare case.
+      // To fix this we need to compare each key/val pairs.
+      // It’s too expansive.
+      // We believe that developers should not want to do this.
+      test(function() {},
+      {
+        block: 'b',
+        mods: { m: 'v' },
+        mix: { block: 'b', mods: { m: 'v' } }
+      },
+      '<div class="b b_m_v b_m_v"></div>');
+    });
+  });
+
+  describe('the same elem', function() {
+    // Weird case, but for completeness why not to check it
+    it('should not duplicate elem class if mix is the same elem',
+      function() {
+      test(function() {},
+      {
+        block: 'b',
+        elem: 'e',
+        mix: { elem: 'e' }
+      },
+      '<div class="b__e"></div>');
+    });
+
+    // Weird case, but for completeness why not to check it
+    it('should not duplicate elem class if mix is the same block elem',
+      function() {
+      test(function() {},
+      {
+        block: 'b',
+        elem: 'e',
+        mix: { block: 'b', elem: 'e' }
+      },
+      '<div class="b__e"></div>');
+    });
+
+    // Weird case, but for completeness why not to check it
+    it('should not duplicate elem class if mix the same elem to elem in block',
+      function() {
+      test(function() {},
+      {
+        block: 'b',
+        content: {
+          elem: 'e',
+          mix: { elem: 'e' }
+        }
+      },
+      '<div class="b"><div class="b__e"></div></div>');
+    });
+  });
+
+  describe('the same elem with elemMods', function() {
+    it('should not duplicate elem class ' +
+      'if mix is the same elem with elemMod',
+      function() {
+      test(function() {},
+      {
+        block: 'b',
+        elem: 'e',
+        mix: { elem: 'e', elemMods: { modname: 'modval' } }
+      },
+      '<div class="b__e b__e_modname_modval"></div>');
+    });
+
+    it('should not duplicate elem class ' +
+       'if mix is the same block elem with elemMods',
+      function() {
+      test(function() {},
+      {
+        block: 'b',
+        elem: 'e',
+        mix: { block: 'b', elem: 'e', elemMods: { modname: 'modval' } }
+      },
+      '<div class="b__e b__e_modname_modval"></div>');
+    });
+
+    it('should duplicate elem elemMod class ' +
+       'if mix is the same elem elemMod to elem with elemMods in block',
+      // Because who cares? It’s pretty rare case.
+      // To fix this we need to compare each key/val pairs.
+      // It’s too expansive.
+      // We believe that developers should not want to do this.
+      function() {
+      test(function() {},
+      {
+        block: 'b',
+        content: {
+          elem: 'e',
+          elemMods: { modname: 'modval' },
+          mix: { elem: 'e', elemMods: { modname: 'modval' } }
+        }
+      },
+      '<div class="b"><div class="b__e b__e_modname_modval ' +
+        'b__e_modname_modval"></div></div>');
+    });
   });
 });


### PR DESCRIPTION
Related: https://github.com/bem/bem-core/pull/805

+15 test cases
–1 bug


## Fixed (degradation)

### 1. bemhtml should duplicate block class if mix several block with mods to elem in the same block.

Because block class must have for mix block with mods to block elem.

Example:
```js
({
    block: 'b',
    content: {
        elem: 'e',
        mix: [
            { block: 'b', mods: { m1: 'v1' } },
            { block: 'b', mods: { m2: 'v2' } }
        ]
    }
});
```

4.3.4 result:
```html
<div class="b"><div class="b__e b b_m1_v1 b b_m2_v2"></div></div>
```
[demo](http://bem.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20content%3A%20%7B%0A%20%20%20%20%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20%20%20%20%20mix%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%20block%3A%20%27b%27%2C%20mods%3A%20%7B%20m1%3A%20%27v1%27%20%7D%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%20block%3A%20%27b%27%2C%20mods%3A%20%7B%20m2%3A%20%27v2%27%20%7D%20%7D%0A%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A%7D)%3B)

5.0.0 result:
```html
<div class="b"><div class="b__e b b"></div></div>
```
[demo](http://miripiruni.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20content%3A%20%7B%0A%20%20%20%20%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20%20%20%20%20mix%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%20block%3A%20%27b%27%2C%20mods%3A%20%7B%20m1%3A%20%27v1%27%20%7D%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%20block%3A%20%27b%27%2C%20mods%3A%20%7B%20m2%3A%20%27v2%27%20%7D%20%7D%0A%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A%7D));

This PR result:
```html
<div class="b"><div class="b__e b b_m1_v1 b b_m2_v2"></div></div>
```

## Improved

### 2. bemhtml should not duplicate block class if mix is the same block with mods.

```js
({
    block: 'b',
    mix: [
        { block: 'b', mods: { m1: 'v1' } },
        { block: 'b', mods: { m2: 'v2' } }
    ]
});
```

4.3.4 result:
```html
<div class="b b b_m1_v1 b b_m2_v2"></div>
```

[demo](http://bem.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20mix%3A%20%5B%0A%20%20%20%20%20%20%20%20%7B%20block%3A%20%27b%27%2C%20mods%3A%20%7B%20m1%3A%20%27v1%27%20%7D%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%20block%3A%20%27b%27%2C%20mods%3A%20%7B%20m2%3A%20%27v2%27%20%7D%20%7D%0A%20%20%20%20%5D%0A%7D)%3B)

5.0.0 result:
```html
<div class="b b b_m1_v1 b b_m2_v2"></div>
```

[demo](http://miripiruni.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20mix%3A%20%5B%0A%20%20%20%20%20%20%20%20%7B%20block%3A%20%27b%27%2C%20mods%3A%20%7B%20m1%3A%20%27v1%27%20%7D%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%20block%3A%20%27b%27%2C%20mods%3A%20%7B%20m2%3A%20%27v2%27%20%7D%20%7D%0A%20%20%20%20%5D%0A%7D)%3B)


This PR result:
```html
<div class="b b_m1_v1 b_m2_v2"></div>
```


### 3. bemhtml should not duplicate elem class if mix is the same elem.

Weird case, but for completeness why not to check it

```js
({
    block: 'b',
    elem: 'e',
    mix: { elem: 'e' }
});
```

4.3.4 result:
```html
<div class="b__e b__e"></div>
```

[demo](http://bem.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20mix%3A%20%7B%20elem%3A%20%27e%27%20%7D%0A%7D)%3B)

5.0.0 result:
```html
<div class="b__e b__e"></div>
```

[demo](http://miripiruni.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20mix%3A%20%7B%20elem%3A%20%27e%27%20%7D%0A%7D)%3B)

This PR result:
```html
<div class="b__e"></div>
```

### 4. bemhtml should not duplicate elem class if mix is the same block elem.

Weird case, but for completeness why not to check it.

```js
({
    block: 'b',
    elem: 'e',
    mix: { block: 'b', elem: 'e' }
});
```

4.3.4 result:
```html
<div class="b__e b__e"></div>
```

[demo](http://bem.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20mix%3A%20%7B%20block%3A%20%27b%27%2C%20elem%3A%20%27e%27%20%7D%0A%7D)%3B)


5.0.0 result:
```html
<div class="b__e b__e"></div>
```

[demo](http://miripiruni.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20mix%3A%20%7B%20block%3A%20%27b%27%2C%20elem%3A%20%27e%27%20%7D%0A%7D)%3B)

This PR result:
```html
<div class="b__e"></div>
```

### 5. bemhtml should not duplicate elem class if mix the same elem to elem in block.

Weird case, but for completeness why not to check it.

```js
({
    block: 'b',
    content: {
        elem: 'e',
        mix: { elem: 'e' }
    }
});
```

4.3.4 result:
```html
<div class="b"><div class="b__e b__e"></div></div>
```

[demo](http://bem.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20content%3A%20%7B%0A%20%20%20%20%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20%20%20%20%20mix%3A%20%7B%20elem%3A%20%27e%27%20%7D%0A%20%20%20%20%7D%0A%7D)%3B)

5.0.0 result:
```html
<div class="b"><div class="b__e b__e"></div></div>
```

[demo](http://miripiruni.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20content%3A%20%7B%0A%20%20%20%20%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20%20%20%20%20mix%3A%20%7B%20elem%3A%20%27e%27%20%7D%0A%20%20%20%20%7D%0A%7D)%3B)

This PR result:
```html
<div class="b"><div class="b__e"></div></div>
```



### 6. bemhtml should not duplicate elem class if mix is the same block elem with elemMods.

```js
({
    block: 'b',
    elem: 'e',
    mix: { elem: 'e', elemMods: { modname: 'modval' } }
});
```

4.3.4 result:
```html
<div class="b__e b__e b__e_modname_modval"></div>
```

[demo](http://bem.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20mix%3A%20%7B%20elem%3A%20%27e%27%2C%20elemMods%3A%20%7B%20modname%3A%20%27modval%27%20%7D%20%7D%0A%7D)%3B)

5.0.0 result:
```html
<div class="b__e b__e b__e_modname_modval"></div>
```

[demo](http://miripiruni.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20mix%3A%20%7B%20elem%3A%20%27e%27%2C%20elemMods%3A%20%7B%20modname%3A%20%27modval%27%20%7D%20%7D%0A%7D)%3B)

This PR result:
```html
<div class="b__e b__e_modname_modval"></div>
```

### 7. bemhtml should not duplicate block elem elemMods class

```js
({
    block: 'b',
    elem: 'e',
    mix: { block: 'b', elem: 'e', elemMods: { modname: 'modval' } }
});
```

4.3.4 result:
```html
<div class="b__e b__e b__e_modname_modval"></div>
```

[demo](http://bem.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20mix%3A%20%7B%20block%3A%20%27b%27%2C%20elem%3A%20%27e%27%2C%20elemMods%3A%20%7B%20modname%3A%20%27modval%27%20%7D%20%7D%0A%7D)%3B)

5.0.0 result:
```html
<div class="b__e b__e b__e_modname_modval"></div>
```

[demo](http://miripiruni.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20mix%3A%20%7B%20block%3A%20%27b%27%2C%20elem%3A%20%27e%27%2C%20elemMods%3A%20%7B%20modname%3A%20%27modval%27%20%7D%20%7D%0A%7D)%3B)

This PR result:
```html
<div class="b__e b__e_modname_modval"></div>
```


## “Who cares” cases (zero cost but enjoyable)

Weird cases, but for completeness why not to check it.

### 8. bemhtml should duplicate block mods class if mix is the same block with mods.

But who cares? It’s pretty rare case.
To fix this we need to compare each key/value pairs. It’s too expensive.
I believe that developers should not want to do this.

```js
({
    block: 'b',
    mods: { m: 'v' },
    mix: { block: 'b', mods: { m: 'v' } }
});
```

4.3.4 result:
```html
<div class="b b_m_v b b_m_v"></div>
```

[demo](http://bem.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20mods%3A%20%7B%20m%3A%20%27v%27%20%7D%2C%0A%20%20%20%20mix%3A%20%7B%20block%3A%20%27b%27%2C%20mods%3A%20%7B%20m%3A%20%27v%27%20%7D%20%7D%0A%7D)%3B)

5.0.0 result:
```html
<div class="b b_m_v b b_m_v"></div>
```

[demo](http://miripiruni.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20mods%3A%20%7B%20m%3A%20%27v%27%20%7D%2C%0A%20%20%20%20mix%3A%20%7B%20block%3A%20%27b%27%2C%20mods%3A%20%7B%20m%3A%20%27v%27%20%7D%20%7D%0A%7D)%3B)

This PR result:
```html
<div class="b b_m_v b_m_v"></div>
```


### 9. bemhtml should duplicate elem elemMod class

```js
({
    block: 'b',
    content: {
        elem: 'e',
        elemMods: { modname: 'modval' },
        mix: { elem: 'e', elemMods: { modname: 'modval' } }
    }
});
```

But who cares? It’s pretty rare case.
To fix this we need to compare each key/value pairs. It’s too expensive.
I believe that developers should not want to do this.

4.3.4 result:
```html
<div class="b">
    <div class="b__e b__e_modname_modval b__e b__e_modname_modval"></div>
</div>
```

[demo](http://bem.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20content%3A%20%7B%0A%20%20%20%20%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20%20%20%20%20elemMods%3A%20%7B%20modname%3A%20%27modval%27%20%7D%2C%0A%20%20%20%20%20%20%20%20mix%3A%20%7B%20elem%3A%20%27e%27%2C%20elemMods%3A%20%7B%20modname%3A%20%27modval%27%20%7D%20%7D%0A%20%20%20%20%7D%0A%7D)%3B)

5.0.0 result:
```html
<div class="b">
    <div class="b__e b__e_modname_modval b__e b__e_modname_modval"></div>
</div>
```

[demo](http://miripiruni.github.io/bem-xjst/?bemhtml=&bemjson=(%7B%0A%20%20%20%20block%3A%20%27b%27%2C%0A%20%20%20%20content%3A%20%7B%0A%20%20%20%20%20%20%20%20elem%3A%20%27e%27%2C%0A%20%20%20%20%20%20%20%20elemMods%3A%20%7B%20modname%3A%20%27modval%27%20%7D%2C%0A%20%20%20%20%20%20%20%20mix%3A%20%7B%20elem%3A%20%27e%27%2C%20elemMods%3A%20%7B%20modname%3A%20%27modval%27%20%7D%20%7D%0A%20%20%20%20%7D%0A%7D)%3B)

This PR result:
```html
<div class="b">
    <div class="b__e b__e_modname_modval b__e_modname_modval"></div>
</div>
```

