### PR TITLE
Pass BEMContext instance as argument to template body

### DIFF
--- a/lib/bemxjst/match.js
+++ b/lib/bemxjst/match.js
@@ -48,7 +48,7 @@ function MatchCustom(template, pred) {
 }
 
 MatchCustom.prototype.exec = function exec(context) {
-  return this.body.call(context);
+  return this.body.call(context, context, context.ctx);
 };
 
 function MatchOnce(template) {
@@ -167,7 +167,7 @@ Match.prototype.push = function push(template) {
 
 Match.prototype.tryCatch = function tryCatch(fn, ctx) {
   try {
-    return fn.call(ctx);
+    return fn.call(ctx, ctx, ctx.ctx);
   } catch (e) {
     this.thrownError = e;
   }

--- a/test/runtime-match-test.js
+++ b/test/runtime-match-test.js
@@ -1,0 +1,62 @@
+var fixtures = require('./fixtures')('bemhtml');
+var test = fixtures.test;
+
+describe('Runtime Match', function() {
+  it('should call body function in BEMContext context', function() {
+    test(function() {
+      block('b').def()(function() {
+        return this.constructor.name;
+      });
+    }, { block: 'b' }, 'ContextChild');
+  });
+
+  it('should pass BEMContext as the first argument', function() {
+    test(function() {
+      block('b').def()(function(ctx) {
+        return ctx.constructor.name;
+      });
+    }, { block: 'b' }, 'ContextChild');
+  });
+
+  it('should pass BEMContext instance to custom mode', function() {
+    test(function() {
+      block('b').mode('custom')(function(ctx) {
+        return ctx.constructor.name;
+      });
+      block('b').def()(function() {
+        return apply('custom');
+      });
+    }, { block: 'b' }, 'ContextChild');
+  });
+
+  it('should pass bemjson node as the second argument', function() {
+    test(function() {
+      block('b').def()(function(_, json) {
+        return json.foo;
+      });
+    }, { block: 'b', foo: 'bar' }, 'bar');
+  });
+
+  it('should pass json to custom mode', function() {
+    test(function() {
+      block('b').mode('custom')(function(_, json) {
+        return json.foo;
+      });
+      block('b').def()(function() {
+        return apply('custom');
+      });
+    }, { block: 'b', foo: 'bar' }, 'bar');
+  });
+
+  it('should pass BEMContext instance and json to match method body',
+    function() {
+    test(function() {
+      block('b').match(function(ctx, json) {
+        this._what = json.foo + ' ' + ctx.constructor.name;
+        return true;
+      }).def()(function() {
+        return this._what;
+      });
+    }, { block: 'b', foo: 'This is' }, 'This is ContextChild');
+  });
+});


### PR DESCRIPTION
Fixes #171 

Was not done:
```js
block('*').content()((_, ctx) => [ctx.text, applyNext()]);
```
because it's a sugar for:
```js
block('*').content()({ctx} => [ctx.text, applyNext()]);
```

I'm not sure what's sweeter.