### PR TITLE
Improved error msg about no block subpredicate (print out template)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -32,7 +32,7 @@
     "elem", "local", "wrap", "extend", "oninit", "replace" ],
     "strict"        : false,    // true: Requires all functions run in ES5 Strict Mode
     "maxparams"     : false,    // {int} Max number of formal params allowed per function
-    "maxdepth"      : 3,        // {int} Max depth of nested blocks (within functions)
+    "maxdepth"      : 5,        // {int} Max depth of nested blocks (within functions)
     "maxstatements" : false,    // {int} Max number statements per function
     "maxcomplexity" : false,    // {int} Max cyclomatic complexity per function
     "maxlen"        : false,    // {int} Max number of characters per line
@@ -88,6 +88,7 @@
     // Custom Globals
     "globals"       : {
         "module": true,
-        "test": true
+        "test": true,
+        "BEMXJSTError": true
     }
 }

--- a/lib/bemxjst/error.js
+++ b/lib/bemxjst/error.js
@@ -1,0 +1,14 @@
+function BEMXJSTError(msg, func) {
+  this.name = 'BEMXJSTError';
+  this.message = msg;
+
+  if (Error.captureStackTrace)
+    Error.captureStackTrace(this, func || this.constructor);
+  else
+    this.stack = (new Error()).stack;
+}
+
+BEMXJSTError.prototype = Object.create(Error.prototype);
+BEMXJSTError.prototype.constructor = BEMXJSTError;
+
+exports.BEMXJSTError = BEMXJSTError;

--- a/lib/bemxjst/index.js
+++ b/lib/bemxjst/index.js
@@ -156,9 +156,42 @@ BEMXJST.prototype.groupEntities = function groupEntities(tree) {
       j--;
     }
 
-    // TODO(indutny): print out the template itself
-    if (block === null)
-      throw new Error('block("...") not found in one of the templates');
+    if (block === null) {
+      var msg = 'block(…) subpredicate is not found.\n' +
+      '    See template with subpredicates:\n     * ';
+
+      for (var j = 0; j < template.predicates.length; j++) {
+        var pred = template.predicates[j];
+
+        if (j !== 0)
+          msg += '\n     * ';
+
+        if (pred.key === '_mode') {
+          msg += pred.value + '()';
+        } else {
+          if (Array.isArray(pred.key)) {
+            msg += pred.key[0].replace('mods', 'mod')
+              .replace('elemMods', 'elemMod') +
+              '(\'' + pred.key[1] + '\', \'' + pred.value + '\')';
+          } else if (!pred.value || !pred.key) {
+            msg += 'match(…)';
+          } else {
+            msg += pred.key + '(\'' + pred.value + '\')';
+          }
+        }
+      }
+
+      msg += '\n    And template body: \n    (' +
+        (typeof template.body === 'function' ?
+          template.body :
+          JSON.stringify(template.body)) + ')';
+
+      if (typeof BEMXJSTError === 'undefined') {
+        BEMXJSTError = require('./error').BEMXJSTError;
+      }
+
+      throw new BEMXJSTError(msg);
+    }
 
     var key = this.classBuilder.build(block, elem);
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,4 +1,5 @@
 var vm = require('vm');
+var BEMXJSTError = require('./bemxjst/error').BEMXJSTError;
 
 function Compiler(runtime) {
   this.runtime = runtime;
@@ -51,6 +52,19 @@ Compiler.prototype.generate = function generate(code, options) {
   return source;
 };
 
+var _compile = function _compile(fn, exports) {
+  try {
+    fn(exports, console);
+  } catch (e) {
+    if (e instanceof BEMXJSTError)
+      throw new BEMXJSTError(e.message);
+    else
+      throw e;
+  }
+
+  return exports;
+};
+
 Compiler.prototype.compile = function compile(code, options) {
   if (!options) options = {};
 
@@ -60,9 +74,9 @@ Compiler.prototype.compile = function compile(code, options) {
 
   var fn = options.context === 'this' ?
     vm.runInThisContext(out) :
-    vm.runInNewContext(out);
+    vm.runInNewContext(out, { Error: Error, BEMXJSTError: BEMXJSTError });
 
-  fn(exports, console);
+  _compile(fn, exports);
 
   return exports;
 };

--- a/test/templates-syntax-test.js
+++ b/test/templates-syntax-test.js
@@ -1,5 +1,8 @@
 var fixtures = require('./fixtures')('bemhtml');
 var test = fixtures.test;
+var assert = require('assert');
+var bemxjst = require('../').bemhtml;
+var BEMXJSTError = require('../lib/bemxjst/error').BEMXJSTError;
 
 describe('Templates syntax', function() {
   it('should support block without mode()', function() {
@@ -29,5 +32,14 @@ describe('Templates syntax', function() {
     },
     { block: 'b' },
     '<b></b>');
+  });
+
+  it('should throw error when no block subpredicate', function() {
+    assert.throws(function() {
+      bemxjst.compile(function() {
+        // No block() subpredicate
+        elem('e').tag()('b');
+      });
+    }, BEMXJSTError);
   });
 });


### PR DESCRIPTION
```bash
miripiruni$ cat noblock.js

var bemxjst = require('./');
var bemhtml = bemxjst.bemhtml;
var templates = bemhtml.compile(function() {
    elemMod('em', 'ev')
    .mod('m', 'v')
    .elem('e')
    .attrs()(function() {
       return { id: 'test' };
    });
});
```

## Error with 5.0.0:
```bash
miripiruni$ node noblock.js

evalmachine.<anonymous>:804
      throw new Error('block("...") not found in one of the templates');
            ^
Error: block("...") not found in one of the templates
    at BEMHTML.groupEntities (evalmachine.<anonymous>:804:13)
    at BEMHTML.compile (evalmachine.<anonymous>:750:18)
    at evalmachine.<anonymous>:1899:5
    at Compiler.compile (/Users/miripiruni/Documents/www/bem-xjst-cls/lib/compiler.js:65:3)
    at Object.<anonymous> (/Users/miripiruni/Documents/www/bem-xjst-cls/noblock.js:3:25)
    …
```

## Error with this branch:
```bash
miripiruni$ node noblock.js

/Users/miripiruni/Documents/www/bem-xjst-errors/lib/compiler.js:59
      throw new BEMXJSTError(e.message);
      ^
BEMXJSTError: block(…) subpredicate is not found.
    See template with subpredicates:
     * tag()
    And template body:
    ("span")
    at _compile (/Users/miripiruni/Documents/www/bem-xjst-errors/lib/compiler.js:60:13)
    at Compiler.compile (/Users/miripiruni/Documents/www/bem-xjst-errors/lib/compiler.js:79:3)
    at Object.<anonymous> (/Users/miripiruni/Documents/www/bem-xjst-errors/noblock.js:3:25)
    …
```