### PR TITLE
BEMXJST: generate() should support arrow functions

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,6 +3,7 @@
     // See http://jshint.com/docs/ for more details
 
     "maxerr"        : 50,       // {int} Maximum error before stopping
+    "esversion"     : 6,        // ES6
 
     // Enforcing
     "bitwise"       : false,     // true: Prohibit bitwise operators (&, |, ^, etc.)

--- a/lib/bemxjst/match.js
+++ b/lib/bemxjst/match.js
@@ -92,8 +92,8 @@ function MatchTemplate(mode, template) {
     } else if (pred instanceof CustomMatch) {
       this.predicates[j] = new MatchCustom(this, pred);
 
-    // Push OnceMatch and MatchWrap later, they should not be executed first.
-    // Otherwise they will set flag too early, and body might not be executed
+      // Push OnceMatch and MatchWrap later, they should not be executed first.
+      // Otherwise they will set flag too early, and body might not be executed
     } else if (pred instanceof OnceMatch) {
       j--;
       postpone.push(new MatchOnce(this));

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -15,8 +15,25 @@ Compiler.prototype.generate = function generate(code, options) {
     code = '';
 
   // Yeah, let people pass functions to us!
-  if (typeof code === 'function')
-    code = code.toString().replace(/^function\s*\w*\(\)\s*{|}$/g, '');
+  if (typeof code === 'function') {
+    // Examples:
+    //   function () { … }
+    //   function name() { … }
+    //   function (a, b) { … }
+    //   function name(a, b) { … }
+    var regularFunction = /^function\s*[^{]+{|}$/g;
+
+    // Examples:
+    //   () => { … }
+    //   (a, b) => { … }
+    //   _ => { … }
+    var arrowFunction = /^(_|\(\w|[^=>]+\))\s=>\s{|}$/g;
+
+    code = code.toString();
+    code = code.replace(
+      code.indexOf('function') === 0 ? regularFunction : arrowFunction,
+    '');
+  }
 
   var exportName = options.exportName || 'BEMHTML';
   var engine = options.engine || 'BEMHTML';

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "browserify": "^9.0.6",
-    "jscs": "^1.12.0",
+    "jscs": "^3.0.3",
     "jshint": "^2.7.0",
     "mocha": "2.4.5",
     "chai": "3.5.0"

--- a/test/api-compile-test.js
+++ b/test/api-compile-test.js
@@ -39,6 +39,23 @@ describe('API compile', function() {
     assert.equal(template.apply({ block: 'b2' }), '<div class="b2">ok</div>');
   });
 
+  it('should work with function with parameters', function() {
+    var template;
+
+    // Function with name and parameters
+    /*jshint unused:false*/
+    var functionWithName = function templates(a, b, c) {
+      block('name').content()('yay');
+    };
+
+    assert.doesNotThrow(function() {
+      template = bemxjst.compile(functionWithName);
+    });
+
+    assert.equal(template.apply({ block: 'name' }),
+      '<div class="name">yay</div>');
+  });
+
   it('should work with named function', function() {
     var template;
 
@@ -53,5 +70,50 @@ describe('API compile', function() {
 
     assert.equal(template.apply({ block: 'name' }),
       '<div class="name">yay</div>');
+  });
+
+  it('should work with arrow function', function() {
+    var template;
+    var arrowFunction = function() {};
+    arrowFunction.toString = function() {
+      return '() => { block(\'a\').tag()(\'a\'); }';
+    };
+
+    assert.doesNotThrow(function() {
+      template = bemxjst.compile(arrowFunction);
+    });
+
+    assert.equal(template.apply({ block: 'a' }),
+      '<a class="a"></a>');
+  });
+
+  it('should work with arrow function with params', function() {
+    var template;
+    var arrowFunction = function() {};
+    arrowFunction.toString = function() {
+      return '(a, b, c) => { block(\'a\').tag()(\'a\'); }';
+    };
+
+    assert.doesNotThrow(function() {
+      template = bemxjst.compile(arrowFunction);
+    });
+
+    assert.equal(template.apply({ block: 'a' }),
+      '<a class="a"></a>');
+  });
+
+  it('should work with arrow function with _', function() {
+    var template;
+    var arrowFunction = function() {};
+    arrowFunction.toString = function() {
+      return '_ => { block(\'a\').tag()(\'a\'); }';
+    };
+
+    assert.doesNotThrow(function() {
+      template = bemxjst.compile(arrowFunction);
+    });
+
+    assert.equal(template.apply({ block: 'a' }),
+      '<a class="a"></a>');
   });
 });

--- a/test/modes-elemmod-test.js
+++ b/test/modes-elemmod-test.js
@@ -17,8 +17,9 @@ describe('Modes elemMod(elemModName, elemModVal)', function() {
     },
     {
       block: 'b',
-      content: { elem: 'inner',
-      elemMods: { valid: true }
+      content: {
+        elem: 'inner',
+        elemMods: { valid: true }
       }
     },
     '<div class="b">' +


### PR DESCRIPTION
Fix for #259 

So, the checks have failed [because of Node v0.1 and Node v0.12](https://travis-ci.org/bem/bem-xjst/builds/131134175). 

WIP: I would like to disable ES6 tests for old Node.js. 

cc @zxqfox 