### PR TITLE
Tree: Support `mod(m)` and `elemMod(em)` without second argument.

### DIFF
--- a/lib/bemxjst/tree.js
+++ b/lib/bemxjst/tree.js
@@ -340,10 +340,12 @@ Tree.prototype.mode = function mode(name) {
 };
 
 Tree.prototype.mod = function mod(name, value) {
+  if (value === undefined) value = true;
   return this.match(new PropertyMatch([ 'mods', name ], value));
 };
 
 Tree.prototype.elemMod = function elemMod(name, value) {
+  if (value === undefined) value = true;
   return this.match(new PropertyMatch([ 'elemMods', name ], value));
 };
 

--- a/test/modes-elemmod-test.js
+++ b/test/modes-elemmod-test.js
@@ -57,4 +57,12 @@ describe('Modes elemMod(elemModName, elemModVal)', function() {
       '<div class="b__inner b__inner_valid_valid"></div>' +
     '</div>');
   });
+
+  it('should support simple elemMods', function() {
+    test(function() {
+      block('b').elem('e').elemMod('disabled').tag()('span');
+    },
+    { block: 'b', elem: 'e', elemMods: { disabled: true } },
+    '<span class="b__e b__e_disabled"></span>');
+  });
 });

--- a/test/modes-mod-test.js
+++ b/test/modes-mod-test.js
@@ -34,4 +34,12 @@ describe('Modes .mod(modName, modVal)', function() {
     { block: 'b', mods: { valid: 'valid' } },
     '<div class="b b_valid_valid"></div>');
   });
+
+  it('should support simple mods', function() {
+    test(function() {
+      block('b').mod('disabled').tag()('span');
+    },
+    { block: 'b', mods: { disabled: true } },
+    '<span class="b b_disabled"></span>');
+  });
 });


### PR DESCRIPTION
Fix for #274 