### PR TITLE
BEMHTML: Support nested mixes

### DIFF
--- a/lib/bemhtml/index.js
+++ b/lib/bemhtml/index.js
@@ -245,7 +245,15 @@ BEMHTML.prototype.renderMix = function renderMix(entity,
         addInit = block && !item.elem;
     }
 
-    // Process nested mixes
+    // Process nested mixes from BEMJSON
+    if (item.mix) {
+      var nested = this.renderMix(entity, item.mix, js, addInit);
+      js = utils.extend(js, nested.jsParams);
+      addInit = nested.addJSInitClass;
+      out += nested.out;
+    }
+
+    // Process nested mixes from Templates
     if (!hasItem || visited[key])
       continue;
 

--- a/lib/bemhtml/index.js
+++ b/lib/bemhtml/index.js
@@ -45,48 +45,78 @@ BEMHTML.prototype.runMany = function runMany(arr) {
   return out;
 };
 
-BEMHTML.prototype.collectMixes = function collectMixes(item, res, context) {
-  res = res || [];
+BEMHTML.prototype.collectMixes = function collectMixes(item, res, context,
+                                                       classBuilder) {
+  res = res || { mixes: [], jsParams: false, addInit: false };
+
   if (!item)
     return res;
 
-  context = context || {
-    block: item.block,
-    elem: item.elem,
-    mods: item.mods,
-    elemMods: item.elemMods
-  };
-
-  if (!item.elem && (item.block || item.mods)) {
-    res.push({
-      block: item.block || context.block,
+  if (typeof item === 'string') {
+    res.mixes.push({ block: item });
+  } else {
+    context = context || {
+      block: item.block,
+      elem: item.elem,
       mods: item.mods,
-      js: item.js
-    });
-    if (item.block)
-      context = { block: item.block, mods: item.mods };
-  } else if (item.elem || (item.elemMods && context.elem)) {
-    res.push({
-      block: item.block || context.block,
-      elem: item.elem || context.elem,
-      elemMods: item.elemMods,
-      js: item.js
-    });
-    if (item.elem)
-      context = {
-        block: item.block || context.block,
-        mods: item.mods || context.mods,
-        elem: item.elem,
-        elemMods: item.elemMods
-      };
-  }
+      elemMods: item.elemMods
+    };
+    if (!item.elem && (item.block || item.mods)) {
+      var block = item.block || context.block;
 
-  if (typeof item === 'string')
-    res.push({ block: item });
+      res.mixes.push({
+        block: block,
+        mods: item.mods,
+        js: item.js
+      });
 
-  if (item.mix) {
-    if (!Array.isArray(item.mix)) item.mix = [ item.mix ];
-    item.mix.map(function(mix) { return collectMixes(mix, res, context); });
+      if (item.js) {
+        if (!res.jsParams) res.jsParams = {};
+        res.jsParams[classBuilder.build(block)] = item.js === true ?
+          {} : item.js;
+
+        if (!res.addInit)
+          res.addInit = block;
+      }
+
+      if (item.block)
+        context = { block: item.block, mods: item.mods };
+
+    } else if (item.elem || (item.elemMods && context.elem)) {
+      var block = item.block || context.block;
+      var elem = item.elem || context.elem;
+
+      res.mixes.push({
+        block: block,
+        elem: elem,
+        elemMods: item.elemMods,
+        js: item.js
+      });
+
+      if (item.js) {
+        if (!res.jsParams) res.jsParams = {};
+        res.jsParams[classBuilder.build(block, elem)] =
+          item.js === true ? {} : item.js;
+
+        if (!res.addInit)
+          res.addInit = block;
+      }
+
+      if (item.elem)
+        context = {
+          block: block,
+          mods: item.mods || context.mods,
+          elem: item.elem,
+          elemMods: item.elemMods
+        };
+    }
+
+    if (item.mix) {
+      if (!Array.isArray(item.mix)) item.mix = [ item.mix ];
+      item.mix.map(function(mix) {
+        return collectMixes(mix, res, context, classBuilder);
+      });
+    }
   }
 
   return res;
@@ -111,36 +141,27 @@ BEMHTML.prototype.render = function render(context,
 
   var out = '<' + tag;
 
-  if (js === true)
-    js = {};
+  var isBEM = bem;
+  if (isBEM === undefined)
+    isBEM = entity.block || entity.elem;
+  isBEM = !!isBEM;
+
+  if (!isBEM && !cls)
+    return this.renderClose(out, context, tag, attrs, isBEM, ctx, content);
 
   var jsParams;
+  if (js === true)
+    js = {};
   if (js) {
     jsParams = {};
     jsParams[entity.jsClass] = js;
   }
-
-  var isBEM = bem;
-  if (isBEM === undefined) {
-    if (ctx.bem === undefined)
-      isBEM = entity.block || entity.elem;
-    else
-      isBEM = ctx.bem;
-  }
-  isBEM = !!isBEM;
-
-  if (cls === undefined)
-    cls = ctx.cls;
 
   var addJSInitClass = jsParams && (
     this._elemJsInstances ?
       (entity.block || entity.elem) :
       (entity.block && !entity.elem)
   );
-
-  if (!isBEM && !cls) {
-    return this.renderClose(out, context, tag, attrs, isBEM, ctx, content);
-  }
 
   out += ' class="';
   if (isBEM) {
@@ -150,21 +171,24 @@ BEMHTML.prototype.render = function render(context,
     out += this.buildModsClasses(entity.block, entity.elem, mods);
 
     if (mix) {
-      var m = this.renderMix(entity,
-                             this.collectMixes({ mix: mix }),
-                             jsParams,
-                             addJSInitClass);
-      out += m.out;
-      jsParams = m.jsParams;
-      addJSInitClass = m.addJSInitClass;
+      var all = this.collectMixes({ mix: mix },
+                                  {
+                                    mixes: [],
+                                    jsParams: jsParams,
+                                    addInit: addJSInitClass
+                                  },
+                                  null,
+                                  this.classBuilder);
+      out += this.renderMix(entity, all.mixes);
+      jsParams = all.jsParams;
+      addJSInitClass = all.addInit;
     }
 
     if (cls)
       out += ' ' + (typeof cls === 'string' ?
                     utils.attrEscape(cls).trim() : cls);
-  } else {
-    if (cls)
-      out += cls.trim ? utils.attrEscape(cls).trim() : cls;
+  } else if (cls) {
+    out += cls.trim ? utils.attrEscape(cls).trim() : cls;
   }
 
   if (addJSInitClass)
@@ -236,14 +260,9 @@ BEMHTML.prototype.renderAttrs = function renderAttrs(attrs) {
   return out;
 };
 
-BEMHTML.prototype.renderMix = function renderMix(entity,
-                                                 mix,
-                                                 jsParams,
-                                                 addJSInitClass) {
+BEMHTML.prototype.renderMix = function renderMix(entity, mix) {
   var visited = {};
   var context = this.context;
-  var js = jsParams;
-  var addInit = addJSInitClass;
 
   visited[entity.jsClass] = true;
 
@@ -280,16 +299,6 @@ BEMHTML.prototype.renderMix = function renderMix(entity,
     out += this.buildModsClasses(block, classElem,
       (item.elem || !item.block && (item._elem || context.elem)) ?
         item.elemMods : item.mods);
-
-    if (item.js) {
-      if (!js)
-        js = {};
-
-      js[classBuilder.build(block, item.elem)] =
-          item.js === true ? {} : item.js;
-      if (!addInit)
-        addInit = block && !item.elem;
-    }
 
     // Process nested mixes from Templates
     if (!hasItem || visited[key])
@@ -328,11 +337,7 @@ BEMHTML.prototype.renderMix = function renderMix(entity,
     }
   }
 
-  return {
-    out: out,
-    jsParams: js,
-    addJSInitClass: addInit
-  };
+  return out;
 };
 
 BEMHTML.prototype.buildModsClasses = function buildModsClasses(block,

--- a/lib/bemhtml/index.js
+++ b/lib/bemhtml/index.js
@@ -45,6 +45,53 @@ BEMHTML.prototype.runMany = function runMany(arr) {
   return out;
 };
 
+BEMHTML.prototype.collectMixes = function collectMixes(item, res, context) {
+  res = res || [];
+  if (!item)
+    return res;
+
+  context = context || {
+    block: item.block,
+    elem: item.elem,
+    mods: item.mods,
+    elemMods: item.elemMods
+  };
+
+  if (!item.elem && (item.block || item.mods)) {
+    res.push({
+      block: item.block || context.block,
+      mods: item.mods,
+      js: item.js
+    });
+    if (item.block)
+      context = { block: item.block, mods: item.mods };
+  } else if (item.elem || (item.elemMods && context.elem)) {
+    res.push({
+      block: item.block || context.block,
+      elem: item.elem || context.elem,
+      elemMods: item.elemMods,
+      js: item.js
+    });
+    if (item.elem)
+      context = {
+        block: item.block || context.block,
+        mods: item.mods || context.mods,
+        elem: item.elem,
+        elemMods: item.elemMods
+      };
+  }
+
+  if (typeof item === 'string')
+    res.push({ block: item });
+
+  if (item.mix) {
+    if (!Array.isArray(item.mix)) item.mix = [ item.mix ];
+    item.mix.map(function(mix) { return collectMixes(mix, res, context); });
+  }
+
+  return res;
+};
+
 BEMHTML.prototype.render = function render(context,
                                            entity,
                                            tag,
@@ -103,7 +150,10 @@ BEMHTML.prototype.render = function render(context,
     out += this.buildModsClasses(entity.block, entity.elem, mods);
 
     if (mix) {
-      var m = this.renderMix(entity, mix, jsParams, addJSInitClass);
+      var m = this.renderMix(entity,
+                             this.collectMixes({ mix: mix }),
+                             jsParams,
+                             addJSInitClass);
       out += m.out;
       jsParams = m.jsParams;
       addJSInitClass = m.addJSInitClass;
@@ -197,10 +247,6 @@ BEMHTML.prototype.renderMix = function renderMix(entity,
 
   visited[entity.jsClass] = true;
 
-  // Transform mix to the single-item array if it's not array
-  if (!Array.isArray(mix))
-    mix = [ mix ];
-
   var classBuilder = this.classBuilder;
 
   var out = '';
@@ -243,14 +289,6 @@ BEMHTML.prototype.renderMix = function renderMix(entity,
           item.js === true ? {} : item.js;
       if (!addInit)
         addInit = block && !item.elem;
-    }
-
-    // Process nested mixes from BEMJSON
-    if (item.mix) {
-      var nested = this.renderMix(entity, item.mix, js, addInit);
-      js = utils.extend(js, nested.jsParams);
-      addInit = nested.addJSInitClass;
-      out += nested.out;
     }
 
     // Process nested mixes from Templates

--- a/test/bemjson-mix-test.js
+++ b/test/bemjson-mix-test.js
@@ -238,4 +238,48 @@ describe('BEMJSON mix', function() {
         'b__e_modname_modval"></div></div>');
     });
   });
+
+  describe('nested mixes', function() {
+    it('should support nested mix', function() {
+      test(function() {},
+      {
+        block: 'b1',
+        mix: {
+          block: 'b2',
+          elem: 'e',
+          mix: {
+            block: 'b3',
+            mods: { test: 'opa' },
+            mix: [
+              { block: 'b4' },
+              { block: 'b5' }
+            ]
+          }
+        }
+      },
+      '<div class="b1 b2__e b3 b3_test_opa b4 b5"></div>');
+    });
+
+    it('should support nested mix with js params', function() {
+      test(function() {},
+      {
+        block: 'b1',
+        mix: {
+          block: 'b2',
+          elem: 'e',
+          mix: {
+            block: 'b3',
+            mods: { test: 'opa' },
+            js: { data: '123' },
+            mix: [
+              { block: 'b4', js: { t: 1 } },
+              { block: 'b5' }
+            ]
+          }
+        }
+      },
+      '<div class="b1 b2__e b3 b3_test_opa b4 b5 i-bem" ' +
+        'data-bem=\'{"b3":{"data":"123"},"b4":{"t":1}}\'></div>');
+    });
+  });
 });


### PR DESCRIPTION
Fix #241

This PR about only support in mix something like this: 

``` js
{
    block: 'b',
    mix: [
        { block: 'a', mix: { block: 'abc' } },
        { block: 'test', mix: [ { block: 'e', js: true }, 'some-block-name', 'another-block' ] }
    ]
}
```
