### PR TITLE
BEMHTML: should properly render unescaped html field if `tag:false` present

### DIFF
--- a/lib/bemxjst/index.js
+++ b/lib/bemxjst/index.js
@@ -277,9 +277,9 @@ BEMXJST.prototype._run = function _run(context) {
   else if (
     context.html &&
     typeof context.html === 'string' &&
+    !context.tag &&
     typeof context.block === 'undefined' &&
     typeof context.elem === 'undefined' &&
-    typeof context.tag === 'undefined' &&
     typeof context.cls === 'undefined' &&
     typeof context.attrs === 'undefined'
   )

--- a/test/runtime-escaping-test.js
+++ b/test/runtime-escaping-test.js
@@ -58,4 +58,12 @@ describe('Content escaping', function() {
       { html: { toString: function () { return '<lol>'; } } } ],
     '<div></div><div></div>');
   });
+
+  it('should ignore `tag:false` if html field exist', function() {
+    test(function() {}, {
+      tag: false,
+      html: '<script>console.log("hello html");</script>'
+    },
+    '<script>console.log("hello html");</script>');
+  });
 });


### PR DESCRIPTION
Fix for #312 