### PR TITLE
Utils: faster escaping functions (see issue #327)

### DIFF
--- a/lib/bemxjst/utils.js
+++ b/lib/bemxjst/utils.js
@@ -1,18 +1,124 @@
-exports.xmlEscape = function(str) {
-  return (str + '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+var amp = '&amp;';
+var lt = '&lt;';
+var gt = '&gt;';
+var quot = '&quot;';
+var singleQuot = '&#39;';
+
+var matchXmlRegExp = /[&<>]/;
+
+exports.xmlEscape = function(string) {
+  var str = '' + string;
+  var match = matchXmlRegExp.exec(str);
+
+  if (!match)
+    return str;
+
+  var escape;
+  var html = '';
+  var index = 0;
+  var lastIndex = 0;
+
+  for (index = match.index; index < str.length; index++) {
+    switch (str.charCodeAt(index)) {
+      case 38: // &
+        escape = amp;
+        break;
+      case 60: // <
+        escape = lt;
+        break;
+      case 62: // >
+        escape = gt;
+        break;
+      default:
+        continue;
+    }
+
+    if (lastIndex !== index)
+      html += str.substring(lastIndex, index);
+
+    lastIndex = index + 1;
+    html += escape;
+  }
+
+  return lastIndex !== index ?
+    html + str.substring(lastIndex, index) :
+    html;
 };
-exports.attrEscape = function(str) {
-  return (str + '')
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;');
+
+var matchAttrRegExp = /["&]/;
+
+exports.attrEscape = function(string) {
+  var str = '' + string;
+  var match = matchAttrRegExp.exec(str);
+
+  if (!match)
+    return str;
+
+  var escape;
+  var html = '';
+  var index = 0;
+  var lastIndex = 0;
+
+  for (index = match.index; index < str.length; index++) {
+    switch (str.charCodeAt(index)) {
+      case 34: // "
+        escape = quot;
+        break;
+      case 38: // &
+        escape = amp;
+        break;
+      default:
+        continue;
+    }
+
+    if (lastIndex !== index)
+      html += str.substring(lastIndex, index);
+
+    lastIndex = index + 1;
+    html += escape;
+  }
+
+  return lastIndex !== index ?
+    html + str.substring(lastIndex, index) :
+    html;
 };
-exports.jsAttrEscape = function(str) {
-  return (str + '')
-    .replace(/&/g, '&amp;')
-    .replace(/'/g, '&#39;');
+
+var matchJsAttrRegExp = /['&]/;
+
+exports.jsAttrEscape = function(string) {
+  var str = '' + string;
+  var match = matchJsAttrRegExp.exec(str);
+
+  if (!match)
+    return str;
+
+  var escape;
+  var html = '';
+  var index = 0;
+  var lastIndex = 0;
+
+  for (index = match.index; index < str.length; index++) {
+    switch (str.charCodeAt(index)) {
+      case 38: // &
+        escape = amp;
+        break;
+      case 39: // '
+        escape = singleQuot;
+        break;
+      default:
+        continue;
+    }
+
+    if (lastIndex !== index)
+      html += str.substring(lastIndex, index);
+
+    lastIndex = index + 1;
+    html += escape;
+  }
+
+  return lastIndex !== index ?
+    html + str.substring(lastIndex, index) :
+    html;
 };
 
 exports.extend = function extend(o1, o2) {


### PR DESCRIPTION
See #327 
Bench results:

```bash
https://github.com/component/escape-html version:
  no special characters    x 22,456,447 ops/sec ±2.61% (192 runs sampled)
  single special character x  7,241,378 ops/sec ±1.32% (191 runs sampled)
  many special characters  x  3,542,471 ops/sec ±0.87% (192 runs sampled)

old bem-xjst 7.0.3 utils.xmlEscape version:
  no special characters    x  3,621,962 ops/sec ±2.34% (184 runs sampled)
  single special character x  2,796,355 ops/sec ±0.92% (192 runs sampled)
  many special characters  x  1,545,772 ops/sec ±0.86% (194 runs sampled)
```

I decided to update `utils.*Escape` functions.

