### PR TITLE
New modes: appendContent and prependContent

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -30,7 +30,8 @@
     "unused"        : true,     // true: Require all defined variables be used
     "predef"        : [ "block", "apply", "applyNext", "applyCtx", "tag",
     "attrs", "bem", "cls", "content", "js", "match", "mix", "mod", "tag",
-    "elem", "local", "wrap", "extend", "oninit", "replace" ],
+    "elem", "local", "wrap", "extend", "oninit", "replace", "appendContent",
+    "prependContent" ],
     "strict"        : false,    // true: Requires all functions run in ES5 Strict Mode
     "maxparams"     : false,    // {int} Max number of formal params allowed per function
     "maxdepth"      : 5,        // {int} Max depth of nested blocks (within functions)

--- a/docs/en/5-templates-syntax.md
+++ b/docs/en/5-templates-syntax.md
@@ -346,6 +346,24 @@ content()(value)
 
 Child nodes. By default, it is taken from the `content` of the current BEMJSON node.
 
+You can use `appendContent` and `prependContent` modes to add child nodes to
+content.
+
+```js
+block('quote')(
+    prependContent()('“'), // add some things before actual content
+    appendContent()('”'), // add content to the end
+    appendContent({ block: 'link' }); // add more content to the end
+);
+```
+```js
+{ block: 'quote', content: 'I came, I saw, I templated.' }
+```
+Result:
+```html
+<div class="quote">“I came, I saw, I templated.”<div class="link"></div></div>
+```
+
 #### mix
 
 ```js

--- a/docs/ru/5-templates-syntax.md
+++ b/docs/ru/5-templates-syntax.md
@@ -339,6 +339,24 @@ content()(value)
 
 Дочерние узлы. По умолчанию будет взято из поля `content` текущего узла BEMJSON.
 
+Чтобы добавить дочерний узел в содержимое вы можете воспользоваться режимами
+`appendContent` и `prependContent`.
+
+```js
+block('quote')(
+    prependContent()('«'),
+    appendContent()('»'),
+    appendContent({ block: 'link' });
+);
+```
+```js
+{ block: 'quote', content: 'Пришел, увидел, отшаблонизировал' }
+```
+Результатом шаблонизации будет строка:
+```html
+<div class="quote">«Пришел, увидел, отшаблонизировал»<div class="link"></div></div>
+```
+
 #### mix
 
 ```js

--- a/lib/bemxjst/index.js
+++ b/lib/bemxjst/index.js
@@ -2,6 +2,7 @@ var inherits = require('inherits');
 
 var Tree = require('./tree').Tree;
 var PropertyMatch = require('./tree').PropertyMatch;
+var AddMatch = require('./tree').AddMatch;
 var Context = require('./context').Context;
 var ClassBuilder = require('./class-builder').ClassBuilder;
 var utils = require('./utils');
@@ -75,7 +76,8 @@ BEMXJST.prototype.compile = function compile(code) {
   var tree = new Tree({
     refs: {
       applyCtx: applyCtxWrap,
-      local: localWrap
+      local: localWrap,
+      apply: apply
     }
   });
 
@@ -141,7 +143,8 @@ BEMXJST.prototype.groupEntities = function groupEntities(tree) {
     elem = undefined;
     for (var j = 0; j < template.predicates.length; j++) {
       var pred = template.predicates[j];
-      if (!(pred instanceof PropertyMatch))
+      if (!(pred instanceof PropertyMatch) &&
+        !(pred instanceof AddMatch))
         continue;
 
       if (pred.key === 'block')

--- a/lib/bemxjst/match.js
+++ b/lib/bemxjst/match.js
@@ -1,5 +1,6 @@
 var tree = require('./tree');
 var PropertyMatch = tree.PropertyMatch;
+var AddMatch = tree.AddMatch;
 var WrapMatch = tree.WrapMatch;
 var CustomMatch = tree.CustomMatch;
 
@@ -50,6 +51,16 @@ MatchWrap.prototype.exec = function exec(context) {
   return res;
 };
 
+function AddWrap(template, pred) {
+  this.template = template;
+  this.key = pred.key;
+  this.value = pred.value;
+}
+
+AddWrap.prototype.exec = function exec(context) {
+  return context[this.key] === this.value;
+};
+
 function MatchTemplate(mode, template) {
   this.mode = mode;
   this.predicates = new Array(template.predicates.length);
@@ -64,6 +75,8 @@ function MatchTemplate(mode, template) {
         this.predicates[j] = new MatchNested(this, pred);
       else
         this.predicates[j] = new MatchProperty(this, pred);
+    } else if (pred instanceof AddMatch) {
+      this.predicates[i] = new AddWrap(this, pred);
     } else if (pred instanceof CustomMatch) {
       this.predicates[j] = new MatchCustom(this, pred);
 

--- a/lib/bemxjst/tree.js
+++ b/lib/bemxjst/tree.js
@@ -128,6 +128,53 @@ ExtendMatch.prototype.wrapBody = function wrapBody(body) {
   };
 };
 
+function AddMatch(mode, refs) {
+  MatchBase.call(this);
+
+  this.mode = mode;
+  this.refs = refs;
+}
+inherits(AddMatch, MatchBase);
+exports.AddMatch = AddMatch;
+
+AddMatch.prototype.wrapBody = function wrapBody(body) {
+  return this[this.mode + 'WrapBody'](body);
+};
+
+AddMatch.prototype.appendContentWrapBody =
+  function appendContentWrapBody(body) {
+  var refs = this.refs;
+  var applyCtx = refs.applyCtx;
+  var apply = refs.apply;
+
+  if (typeof body !== 'function') {
+    return function inlineAppendContentAddAdaptor() {
+      return [ apply('content') , body ];
+    };
+  }
+
+  return function appendContentAddAdaptor() {
+    return [ apply('content'), applyCtx(body.call(this, this, this.ctx)) ];
+  };
+};
+
+AddMatch.prototype.prependContentWrapBody =
+  function prependContentWrapBody(body) {
+  var refs = this.refs;
+  var applyCtx = refs.applyCtx;
+  var apply = refs.apply;
+
+  if (typeof body !== 'function') {
+    return function inlinePrependContentAddAdaptor() {
+      return [ body, apply('content') ];
+    };
+  }
+
+  return function prependContentAddAdaptor() {
+    return [ applyCtx(body.call(this, this, this.ctx)), apply('content') ];
+  };
+};
+
 function CompilerOptions(options) {
   MatchBase.call(this);
   this.options = options;
@@ -175,7 +222,7 @@ Tree.methods = [
   'match', 'wrap', 'block', 'elem', 'mode', 'mod',
   'elemMod', 'def', 'tag', 'attrs', 'cls', 'js',
   'bem', 'mix', 'content', 'replace', 'extend', 'oninit',
-  'xjstOptions'
+  'xjstOptions', 'appendContent', 'prependContent'
 ];
 
 Tree.prototype.build = function build(templates, apply) {
@@ -357,6 +404,17 @@ Tree.prototype.mix = function mix() {
 
 Tree.prototype.content = function content() {
   return this.applyMode(arguments, 'content');
+};
+
+Tree.prototype.appendContent = function appendContent() {
+  return this.content.apply(this, arguments)
+    .match(new AddMatch('appendContent', this.refs));
+};
+
+
+Tree.prototype.prependContent = function prependContent() {
+  return this.content.apply(this, arguments)
+    .match(new AddMatch('prependContent', this.refs));
 };
 
 Tree.prototype.replace = function replace() {

--- a/test/modes-appendcontent-test.js
+++ b/test/modes-appendcontent-test.js
@@ -1,0 +1,43 @@
+var fixtures = require('./fixtures')('bemhtml');
+var test = fixtures.test;
+
+describe('Modes appendContent', function() {
+  it('should support appendContent', function() {
+    test(function() {
+      block('button').appendContent()(function() {
+        return 'some text';
+      });
+    },
+    { block: 'button', content: { block: 'test' } },
+    '<div class="button"><div class="test"></div>some text</div>');
+  });
+
+  it('should support appendContent with literal', function() {
+    test(function() {
+      block('button').appendContent()('more text');
+    },
+    { block: 'button', content: 'text' },
+    '<div class="button">textmore text</div>');
+  });
+
+  it('should accumulate result', function() {
+    test(function() {
+      block('button')(
+        appendContent()('tmpls_1'),
+        appendContent()('tmpls_2')
+      );
+    },
+    { block: 'button', content: { block: 'test' } },
+    '<div class="button"><div class="test"></div>tmpls_1tmpls_2</div>');
+  });
+
+  it('should append things to content', function() {
+    test(function() {
+      block('button').content()({ block: 'tmpl_1' });
+      block('button').appendContent()('tmpl_2');
+      block('tmpl_1').tag()('span');
+    },
+    { block: 'button', content: 'test' },
+    '<div class="button"><span class="tmpl_1"></span>tmpl_2</div>');
+  });
+});

--- a/test/modes-prependcontent-test.js
+++ b/test/modes-prependcontent-test.js
@@ -1,0 +1,42 @@
+var fixtures = require('./fixtures')('bemhtml');
+var test = fixtures.test;
+
+describe('Modes prependContent', function() {
+  it('should support prependContent', function() {
+    test(function() {
+      block('b').prependContent()(function() {
+        return 'before';
+      });
+    },
+    { block: 'b', content: { block: 'test' } },
+    '<div class="b">before<div class="test"></div></div>');
+  });
+
+  it('should support prependContent with literal', function() {
+    test(function() {
+      block('b').prependContent()('before ');
+    },
+    { block: 'b', content: 'text' },
+    '<div class="b">before text</div>');
+  });
+
+  it('should accumulate result', function() {
+    test(function() {
+      block('b')(
+        prependContent()('2'),
+        prependContent()('4')
+      );
+    },
+    { block: 'b', content: ' is the answer' },
+    '<div class="b">42 is the answer</div>');
+  });
+
+  it('should prepend things to content', function() {
+    test(function() {
+      block('b').content()('2');
+      block('b').prependContent()('4');
+    },
+    { block: 'b', content: 'test' },
+    '<div class="b">42</div>');
+  });
+});


### PR DESCRIPTION
Main goal (IMHO): more verbose `appendContent()` rather than `return [ applyNext(), '...' ];`


Some real life code: 
[1](https://nda.ya.ru/3RttkR), [2](https://nda.ya.ru/3Rttmt), [3](https://nda.ya.ru/3Rttnu), [4](https://nda.ya.ru/3RttoN), [5](https://nda.ya.ru/3RttoW), [6](https://nda.ya.ru/3Rttoi), [7](https://nda.ya.ru/3Rttov), [8](https://nda.ya.ru/3Rttox), [9](https://nda.ya.ru/3Rttp3), [10](https://nda.ya.ru/3Rttp5), [11](https://nda.ya.ru/3RttpT), [12](https://nda.ya.ru/3RttpV), [13](https://nda.ya.ru/3RttpX) and etc.

In general, `appendContent()` is shortcut to:
```js
content()(function() {
    return [apply('content'), 'Append Me' ];
});
```

`prependContent()` is shortcut to:
```js
content()(function() {
    return [ 'Prepend Me' , apply('content') ];
});
```