### PR TITLE
TRIVIAL: mod removed as useless

### DIFF
--- a/lib/bemhtml/entity.js
+++ b/lib/bemhtml/entity.js
@@ -17,7 +17,6 @@ function Entity(bemxjst) {
   // "Fast modes"
   this.tag = new Match(this, 'tag');
   this.attrs = new Match(this, 'attrs');
-  this.mod = new Match(this);
   this.js = new Match(this, 'js');
   this.mix = new Match(this, 'mix');
   this.bem = new Match(this, 'bem');


### PR DESCRIPTION
BEMHTML: `Entity.mod` is useless.

See https://github.com/bem/bem-xjst/commit/6280278b04179f89881f62bf6902b498e58d78b8#diff-bad194964bfd200986dd4bcaf15c2303R20