### PR TITLE
attrEscape should escape accent grave (`)

### DIFF
--- a/lib/bemxjst/utils.js
+++ b/lib/bemxjst/utils.js
@@ -3,6 +3,7 @@ var lt = '&lt;';
 var gt = '&gt;';
 var quot = '&quot;';
 var singleQuot = '&#39;';
+var grave = '&#96;';
 
 var matchXmlRegExp = /[&<>]/;
 
@@ -45,7 +46,7 @@ exports.xmlEscape = function(string) {
     html;
 };
 
-var matchAttrRegExp = /["&]/;
+var matchAttrRegExp = /[`"&]/;
 
 exports.attrEscape = function(string) {
   var str = '' + string;
@@ -66,6 +67,10 @@ exports.attrEscape = function(string) {
         break;
       case 38: // &
         escape = amp;
+        break;
+      // XSS using accent grave in IE: https://html5sec.org/#59
+      case 96: // `
+        escape = grave;
         break;
       default:
         continue;

--- a/test/bemjson-attrs-test.js
+++ b/test/bemjson-attrs-test.js
@@ -96,6 +96,16 @@ describe('BEMJSON attrs', function() {
       '"></div>');
   });
 
+  it('should escape the accent grave (`) in values', function() {
+    test(function() {
+      block('b').attrs()(function() {
+        return { attribute: '``onmouseover=alert(1)' };
+      });
+    },
+    { block: 'b' },
+    '<div class="b" attribute="&#96;&#96;onmouseover=alert(1)"></div>');
+  });
+
   // TODO: https://github.com/bem/bem-xjst/issues/188
   xit('should what?', function() {
     test(function() {


### PR DESCRIPTION
Fix for #357 
