### PR TITLE
Deps: throw away minimalistic-assert dependency

### DIFF
--- a/lib/bemxjst/tree.js
+++ b/lib/bemxjst/tree.js
@@ -1,4 +1,3 @@
-var assert = require('minimalistic-assert');
 var inherits = require('inherits');
 var utils = require('./utils');
 
@@ -413,7 +412,10 @@ Tree.prototype.match = function match() {
     var arg = arguments[i];
     if (typeof arg === 'function')
       arg = new CustomMatch(arg);
-    assert(arg instanceof MatchBase, 'Wrong .match() argument');
+
+    if (!(arg instanceof MatchBase))
+      throw new Error('Wrong .match() argument');
+
     children[i] = arg;
   }
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "coa": "^1.0.1",
     "inherits": "^2.0.1",
-    "minimalistic-assert": "^1.0.0",
     "q": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
### Changes proposed in this pull request

- minus one dependency: [minimalistic-assert](https://github.com/calvinmetcalf/minimalistic-assert)
- minus 343 bytes (~0,7%) in every bundle

