### PR TITLE
Proposal: fix exportName option

### DIFF
--- a/docs/en/3-api.md
+++ b/docs/en/3-api.md
@@ -11,6 +11,7 @@
   - [Escaping](#escaping)
   - [Runtime linting](#runtime-linting)
   - [Production mode](#production-mode)
+  - [exportName](#exportname-option)
 * [Using thirdparty libraries](#using-thirdparty-libraries)
 * [Extending BEMContext](#extending-bemcontext)
 * [Bundling](#bundling)
@@ -423,6 +424,14 @@ $ cat stdout.txt
 $ cat stderr.txt
 BEMXJST ERROR: cannot render block b1, elem undefined, mods {}, elemMods {} [TypeError: Cannot read property 'undef' of undefined]
 ```
+
+### exportName option
+
+You can use `exportName` option for choose name of variable where engine will
+be exported. By default it’s BEMHTML or BEMTREE.
+
+For example read next.
+
 
 ### Using thirdparty libraries
 

--- a/docs/ru/3-api.md
+++ b/docs/ru/3-api.md
@@ -11,6 +11,7 @@
   - [Экранирование](#Экранирование)
   - [Runtime проверки ошибок в шаблонах и входных данных](#runtime-проверки-ошибок-в-шаблонах-и-входных-данных)
   - [Режим production](#Режим-production)
+  - [exportName](#Настройка-exportname)
 * [Подключение сторонних библиотек](#Подключение-сторонних-библиотек)
 * [Расширение BEMContext](#Расширение-bemcontext)
 * [Создание бандла](#Создание-бандла)
@@ -418,6 +419,13 @@ $ cat stderr.txt
 BEMXJST ERROR: cannot render block b1, elem undefined, mods {}, elemMods {} [TypeError: Cannot read property 'undef' of undefined]
 ```
 
+### Настройка exportName
+
+Вы можете использовать опцию `exportName` чтобы выбрать имя переменной, в
+которой будет храниться движок. По умолчанию движки хранятся в BEMHTML и BEMTREE.
+
+За примером обратитесь к следующему разделу, про создание бандла.
+
 
 ## Подключение сторонних библиотек
 
@@ -530,13 +538,27 @@ var html = templates.apply(bemjson);
 
 ```js
 var bemxjst = require('bem-xjst');
-var bundle = bemxjst.bemhtml.generate(function() {
+var bemhtml = bemxjst.bemhtml;
+
+var fs = require('fs');
+
+var bundle = bemhtml.generate(function() {
     // пользовательские шаблоны
     // ...
+
+}, { exportName: 'bemhtml8x' });
+
+// Записываем бандл на файловую систему
+fs.writeFile('bundle.js', bundle, function(err) {
+  if (err) return console.error(err);
+  console.log('Done');
 });
 ```
 
-В `bundle` будет строка, содержащая JS-код ядра BEMHTML и пользовательских шаблонов.
+В результате вы получите файл `bundle.js`, в котором будет лежать код движка и
+пользовательские шаблоны. Код движка будет доступен в переменной bemhtml8x и
+полностью готов к исполению в браузерах, node.js или любой виртуальной машине
+JS.
 
 ***
 


### PR DESCRIPTION
Fixes #397 

I found that if I change exportName option to something not `bemhtml` or `bemtree` then compiler falls with error.

I think there is something unintelligible. We have two options: `engine` and `exportName`. In the beginning, I thought `exportName` determines name of variable that contains bundle and `engine` determines which engine (BEMHTML/BEMTREE) need to export.

But it works not so: `exportName` and `engine` can be only `BEMHTML` or `BEMTREE`.

May I change it like I do it it in PR?
