### PR TITLE
Use bem-xjst in Node.js without bundling via browserify (#407 fixed)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,12 @@
-var fs = require('fs');
-var Compiler = require('./lib/compiler').Compiler;
+var Compiler = require('./lib/compiler');
 var _cache = {};
 
 function getEngine(engineName) {
-  if (_cache[engineName]) return _cache[engineName];
+  var engine = _cache[engineName];
 
-  var runtime = require('./lib/' + engineName);
-  var pathToBundle = require.resolve('./lib/' + engineName + '/bundle');
-  var sourceBundle = fs.readFileSync(pathToBundle, 'utf8');
+  return engine || (engine = new Compiler(engineName));
+};
 
-  runtime.source = sourceBundle;
-
-  return _cache[engineName] = new Compiler(runtime);
-}
 
 module.exports = {
   get bemtree() { return getEngine('bemtree'); },

--- a/lib/bemxjst/index.js
+++ b/lib/bemxjst/index.js
@@ -115,17 +115,15 @@ BEMXJST.prototype.compile = function compile(code) {
   this.oninit = out.oninit;
 };
 
+BEMXJST.prototype.getTemplate = function(code, options) {
+  this.compile(code, options);
+
+  return this.exportApply();
+};
+
 BEMXJST.prototype.recompileInput = function recompileInput(code) {
-  var args = BEMXJST.prototype.locals;
-  var out = code.toString();
-
-  // Strip the function
-  out = out.replace(/^function[^{]+{|}$/g, '');
-
-  // And recompile it with right arguments
-  out = new Function(args.join(', '), out);
-
-  return out;
+  return new Function(BEMXJST.prototype.locals.join(', '),
+                      utils.fnToString(code));
 };
 
 BEMXJST.prototype.groupEntities = function groupEntities(tree) {
@@ -513,23 +511,28 @@ BEMXJST.prototype.applyMode = function applyMode(mode, changes) {
 
 BEMXJST.prototype.exportApply = function exportApply(exports) {
   var self = this;
-  exports.apply = function apply(context) {
+  var ret = exports || {};
+
+  ret.apply = function apply(context) {
     return self.run(context);
   };
 
   // Add templates at run time
-  exports.compile = function compile(templates) {
-    return self.compile(templates);
+  ret.compile = function compile(templates) {
+    self.compile(templates);
+    return ret;
   };
 
   var sharedContext = {};
 
-  exports.BEMContext = this.contextConstructor;
-  sharedContext.BEMContext = exports.BEMContext;
+  ret.BEMContext = this.contextConstructor;
+  sharedContext.BEMContext = ret.BEMContext;
 
   for (var i = 0; i < this.oninit.length; i++) {
     var oninit = this.oninit[i];
 
-    oninit(exports, sharedContext);
+    oninit(ret, sharedContext);
   }
+
+  return ret;
 };

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,33 +1,41 @@
-var vm = require('vm');
-var BEMXJSTError = require('./bemxjst/error').BEMXJSTError;
 var fnToString = require('./bemxjst/utils').fnToString;
+var engines = {
+  bemhtml: require('./bemhtml'),
+  bemtree: require('./bemtree')
+};
 
-function Compiler(runtime) {
-  this.runtime = runtime;
+function Compiler(engineName) {
+  this.engineName = engineName;
 }
 
-exports.Compiler = Compiler;
+function getCode(code, isRuntimeLint) {
+  return isRuntimeLint ?
+    (fnToString(code) + ';' + fnToString(require('../runtime-lint')))
+      : fnToString(code);
+}
+
+Compiler.prototype.compile = function compile(code, options) {
+  if (!options) options = {};
+  var api = new engines[this.engineName](options);
+  return api.getTemplate(getCode(code, options.runtimeLint), options);
+};
 
 Compiler.prototype.generate = function generate(code, options) {
   if (!options) options = {};
-
   code = fnToString(code);
 
-  var exportName = options.exportName || 'BEMHTML';
-  var engine = options.engine || 'BEMHTML';
-
-  var locals = this.runtime.prototype.locals;
-
-  if (options.runtimeLint)
-    code = code + ';' + require('fs')
-      .readFileSync('./runtime-lint/index.js', 'utf8');
+  var exportName = this.engineName.toUpperCase();
 
   var source = [
     '/// -------------------------------------',
     '/// --------- BEM-XJST Runtime Start ----',
     '/// -------------------------------------',
     'var ' + exportName + ' = function(module, exports) {',
-    this.runtime.source + ';',
+    require('fs').readFileSync(
+      require.resolve('./' + this.engineName + '/bundle'),
+      'utf8'
+    ),
+    ';',
     '  return module.exports ||',
     '      exports.' + exportName + ';',
     '}({}, {});',
@@ -35,12 +43,14 @@ Compiler.prototype.generate = function generate(code, options) {
     '/// --------- BEM-XJST Runtime End ------',
     '/// -------------------------------------',
     '',
-    'var api = new ' + engine + '(' + JSON.stringify(options) + ');',
+    'var api = new ' + exportName + '(' + JSON.stringify(options) + ');',
     '/// -------------------------------------',
     '/// ------ BEM-XJST User-code Start -----',
     '/// -------------------------------------',
-    'api.compile(function(' + locals.join(', ') + ') {',
-    code + ';',
+    'api.compile(function(',
+    require('./bemxjst').prototype.locals.join(', '),
+    ') {',
+    getCode(code, options.runtimeLint) + ';',
     '});',
     'api.exportApply(exports);',
     '/// -------------------------------------',
@@ -51,35 +61,4 @@ Compiler.prototype.generate = function generate(code, options) {
   return source;
 };
 
-var _compile = function _compile(fn, exports) {
-  try {
-    fn(exports, console);
-  } catch (e) {
-    if (e instanceof BEMXJSTError)
-      throw new BEMXJSTError(e.message);
-    else
-      throw e;
-  }
-
-  return exports;
-};
-
-Compiler.prototype.compile = function compile(code, options) {
-  if (!options) options = {};
-
-  var out = this.generate(code, options);
-
-  out = '(function(exports, console) {' + out + '})';
-  var exports = {};
-
-  var fn = options.context === 'this' ?
-    vm.runInThisContext(out) :
-    vm.runInNewContext(out, {
-      console: console,
-      Error: Error,
-      BEMXJSTError: BEMXJSTError });
-
-  _compile(fn, exports);
-
-  return exports;
-};
+module.exports = Compiler;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "npm run make && npm run test:lint && npm run test:coverage && npm run size",
     "test:lint": "jscs `ls lib/*.js lib/**/*.js test/*.js | grep -v bundle` && jshint `ls lib/*.js lib/**/*.js test/*.js | grep -v bundle`",
     "test:mocha": "mocha --reporter=spec test/*-test.js",
-    "test:coverage": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- -u bdd -R spec test/*-test.js",
+    "test:coverage": "./node_modules/.bin/istanbul cover -x '**/runtime-lint/**' ./node_modules/mocha/bin/_mocha -- -u bdd -R spec test/*-test.js",
     "size": "npm run size:bemhtml && npm run size:bemtree",
     "size:bemhtml": "ls -ola ./lib/bemhtml/bundle.js | awk '{print \"BEMHTML Bundle Size:\", $4\" B\"}'",
     "size:bemtree": "ls -ola ./lib/bemtree/bundle.js | awk '{print \"BEMTREE Bundle Size:\", $4\" B\"}'"

--- a/runtime-lint/index.js
+++ b/runtime-lint/index.js
@@ -1,3 +1,4 @@
+module.exports = function(match, block, elem, mod, elemMod, oninit, xjstOptions, wrap, replace, extend, mode, def, content, appendContent, prependContent, attrs, addAttrs, js, addJs, mix, addMix, mods, addMods, addElemMods, elemMods, tag, cls, bem, local, applyCtx, applyNext, apply) {
 var collectMixes = function collectMixes(item, res, context) {
   res = res || [];
   if (!item)
@@ -320,3 +321,5 @@ block('*')(
     return applyNext();
   })
 );
+
+};


### PR DESCRIPTION
Fixes #407 

## Changes proposed in this pull request

- use required bem-xjst instead of bundled
- All public API not changed


## API Demo (compile(), apply(), generate())

```js
$ cat test.js
var bemhtml = require('./').bemhtml;
var libs = {
  jscs: require('jscs'),
  chai: require('chai')
};

var templates = function templates() {
  block('a').content()(function() {

    console.log(this.require('chai').version);
    console.log(this.chai.version);

    return applyNext();
  });
};

var htmlTemplates = bemhtml.compile(templates);

htmlTemplates.BEMContext.prototype.require = function require(libName) {
  return libs[libName];
};

htmlTemplates.BEMContext.prototype.chai = require('chai');

var bemjson = { block: 'a', content: 'First' };

console.log(htmlTemplates.apply(bemjson));

htmlTemplates.compile(function() {
  block('a').mix()('mixed');
});
console.log(htmlTemplates.apply(bemjson));

require('fs').writeFileSync('bemhtml-runtime.js', bemhtml.generate(function() {
  block('a').tag()('span');
}, { runtimeLint: true }));
```

```
$ node test
3.5.0
3.5.0
<div class="a">First</div>
3.5.0
3.5.0
<div class="a mixed">First</div>
```

```
$ node
> var b = require('./bemhtml-runtime')
undefined
> var t = b.compile()
undefined
> t.apply({block:'a'})
'<span class="a"></span>'
> t.apply({block:'a__b'})

BEM-XJST WARNING: wrong block name.
Block name can not contain modifier delimeter nor elem delimeter.
block: a__b
ctx: {"block":"a__b"}

>
(To exit, press ^C again or type .exit)
>
```