### PR TITLE
Compiler .generate(): do not require in runtime

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,7 +1,12 @@
 var fnToString = require('./bemxjst/utils').fnToString;
+var readFileSync = require('fs').readFileSync;
 var engines = {
   bemhtml: require('./bemhtml'),
   bemtree: require('./bemtree')
+};
+var bundles = {
+  bemhtml: readFileSync(require.resolve('./bemhtml/bundle'), 'utf8'),
+  bemtree: readFileSync(require.resolve('./bemtree/bundle'), 'utf8')
 };
 
 function Compiler(engineName) {
@@ -31,11 +36,8 @@ Compiler.prototype.generate = function generate(code, options) {
     '/// --------- BEM-XJST Runtime Start ----',
     '/// -------------------------------------',
     'var ' + exportName + ' = function(module, exports) {',
-    require('fs').readFileSync(
-      require.resolve('./' + this.engineName + '/bundle'),
-      'utf8'
-    ),
-    ';',
+      bundles[this.engineName],
+      ';',
     '  return module.exports ||',
     '      exports.' + exportName + ';',
     '}({}, {});',


### PR DESCRIPTION
Because of enb-bemxjst use mockFs.

https://github.com/enb/enb-bemxjst/commit/0898f103dc73d873e55bd29558060a9e3717519b#diff-8e61276023edef77cdb47a206a441d33L308

And because of we can require once at start.