### PR TITLE
BEMXJST: Revert exportApply optimization

### DIFF
--- a/lib/bemxjst/index.js
+++ b/lib/bemxjst/index.js
@@ -516,6 +516,9 @@ BEMXJST.prototype.exportApply = function(exports) {
 
   exports.BEMContext = self.contextConstructor;
 
-  for (var i = 0; i < self.oninit.length; i++)
-    self.oninit[i](exports, { BEMContext: exports.BEMContext });
+  for (var i = 0; i < self.oninit.length; i++) {
+    // NOTE: oninit has global context instead of BEMXJST
+    var oninit = self.oninit[i];
+    oninit(exports, { BEMContext: exports.BEMContext });
+  }
 };

--- a/test/init-test.js
+++ b/test/init-test.js
@@ -55,4 +55,16 @@ describe('oninit', function() {
       }
     }, '[4.[3.[0.<div class="b1">][2.[1.<div class="b2">]</div>]</div>]]');
   });
+
+  it('should use global object as `this`', function () {
+    test(function() {
+      oninit(function() {
+        this._something = { blah: 42 };
+      });
+      block('b1').replace()(function() {
+        /* global _something */
+        return _something.blah;
+      });
+    }, { block: 'b1' }, '42');
+  });
 });


### PR DESCRIPTION
`oninit` should have global context at least for backward compatibility.