### PR TITLE
Rollback function reuse in recompileInput

### DIFF
--- a/lib/bemxjst/index.js
+++ b/lib/bemxjst/index.js
@@ -121,8 +121,12 @@ BEMXJST.prototype.getTemplate = function(code, options) {
 };
 
 BEMXJST.prototype.recompileInput = function(code) {
-  return new Function(BEMXJST.prototype.locals.join(', '),
-                      utils.fnToString(code));
+  var args = BEMXJST.prototype.locals;
+  // Reuse function if it already has right arguments
+  if (typeof code === 'function' && code.length === args.length)
+    return code;
+
+  return new Function(args.join(', '), utils.fnToString(code));
 };
 
 BEMXJST.prototype.groupEntities = function(tree) {


### PR DESCRIPTION
It was removed in https://github.com/bem/bem-xjst/commit/4ed06f1b84951081870702124e221806b4ee7614#diff-afb54847cb75c3ad58adbcd400fa4c46L120 and results in that [__bem_xjst_libs__](https://github.com/enb/enb-bemxjst/search?utf8=✓&q=__bem_xjst_libs__) is now `undefined`.

Caught in `bem-core` tmpl specs.