### PR TITLE
feat (Demo): engine and version into URL

### DIFF
--- a/common.blocks/demo/demo.deps.js
+++ b/common.blocks/demo/demo.deps.js
@@ -2,6 +2,7 @@
     shouldDeps: [
         { block: 'pretty' },
         { block: 'store' },
-        { block: 'functions', elem: 'debounce' }
+        { block: 'functions', elem: 'debounce' },
+        { block: 'querystring' }
     ]
 })

--- a/common.blocks/demo/demo.js
+++ b/common.blocks/demo/demo.js
@@ -73,10 +73,7 @@ modules.define('demo', [ 'i-bem__dom', 'pretty', 'functions__debounce', 'queryst
                 store.get('playground') ||
                 this._getState();
 
-            this._templates.setValue(data.template);
-            this._bemjson.setValue(data.bemjson);
-            this._versionSelect.setValue(data.version);
-            this._engineSelect.setValue(data.engine);
+            this._setState(data);
         },
         _getState: function() {
             return {
@@ -85,6 +82,12 @@ modules.define('demo', [ 'i-bem__dom', 'pretty', 'functions__debounce', 'queryst
                 template: this._getTemplate(),
                 bemjson: this._getBEMJSON()
             };
+        },
+        _setState: function(data) {
+            this._templates.setValue(data.template);
+            this._bemjson.setValue(data.bemjson);
+            this._versionSelect.setValue(data.version);
+            this._engineSelect.setValue(data.engine);
         }
     }, {}));
 

--- a/common.blocks/demo/demo.js
+++ b/common.blocks/demo/demo.js
@@ -1,4 +1,4 @@
-modules.define('demo', [ 'i-bem__dom', 'pretty', 'functions__debounce' ], function(provide, BEMDOM, pretty, debounce) {
+modules.define('demo', [ 'i-bem__dom', 'pretty', 'functions__debounce', 'querystring' ], function(provide, BEMDOM, pretty, debounce, qs) {
 
     provide(BEMDOM.decl('demo', {
         onSetMod: {
@@ -65,36 +65,20 @@ modules.define('demo', [ 'i-bem__dom', 'pretty', 'functions__debounce' ], functi
             this._result.setValue(finalCode);
         },
         save: function() {
-            var template = this._getTemplate(),
-                bemjson = this._getBEMJSON(),
-                version = this._versionSelect.getValue(),
-                engine = this._engineSelect.getValue();
-
-            store.set('playground', {
-                version: version,
-                template: template,
-                bemjson: bemjson,
-                engine: engine
-            });
-
-            history.pushState({}, document.title, location.pathname + '?' + [
-                'template=' + encodeURIComponent(template),
-                'bemjson=' + encodeURIComponent(bemjson),
-                'version=' + encodeURIComponent(version),
-                'engine=' + encodeURIComponent(engine)
-            ].join('&'));
+            store.set('playground', this._getState());
+            history.pushState({}, document.title, location.pathname + '?' + qs.stringify(this._getState()));
         },
         _load: function() {
             var data = parseParams(location.search.split('?')[1]) ||
                 store.get('playground') ||
-                this._getDefaultState();
+                this._getState();
 
             this._templates.setValue(data.template);
             this._bemjson.setValue(data.bemjson);
             this._versionSelect.setValue(data.version);
             this._engineSelect.setValue(data.engine);
         },
-        _getDefaultState: function() {
+        _getState: function() {
             return {
                 template: this._getTemplate(),
                 bemjson: this._getBEMJSON(),

--- a/common.blocks/demo/demo.js
+++ b/common.blocks/demo/demo.js
@@ -80,10 +80,10 @@ modules.define('demo', [ 'i-bem__dom', 'pretty', 'functions__debounce', 'queryst
         },
         _getState: function() {
             return {
-                template: this._getTemplate(),
-                bemjson: this._getBEMJSON(),
                 version: this._versionSelect.getValue(),
-                engine: this._engineSelect.getValue()
+                engine: this._engineSelect.getValue(),
+                template: this._getTemplate(),
+                bemjson: this._getBEMJSON()
             };
         }
     }, {}));

--- a/common.blocks/demo/demo.js
+++ b/common.blocks/demo/demo.js
@@ -70,10 +70,20 @@ modules.define('demo', [ 'i-bem__dom', 'pretty', 'functions__debounce', 'queryst
         },
         _load: function() {
             var data = parseParams(location.search.split('?')[1]) ||
-                store.get('playground') ||
+                this._getStateFromCache() ||
                 this._getState();
 
             this._setState(data);
+        },
+        _getStateFromCache() {
+            var cache = store.get('playground') || {};
+
+            console.log(this.params.version, cache.version);
+
+            if (this.params.version !== cache.version) {
+                return null;
+            }
+            return cache;
         },
         _getState: function() {
             return {

--- a/common.blocks/demo/demo.js
+++ b/common.blocks/demo/demo.js
@@ -78,8 +78,6 @@ modules.define('demo', [ 'i-bem__dom', 'pretty', 'functions__debounce', 'queryst
         _getStateFromCache() {
             var cache = store.get('playground') || {};
 
-            console.log(this.params.version, cache.version);
-
             if (this.params.version !== cache.version) {
                 return null;
             }

--- a/common.blocks/engine-selector/engine-selector.js
+++ b/common.blocks/engine-selector/engine-selector.js
@@ -10,9 +10,18 @@ modules.define('engine-selector', [ 'i-bem__dom'], function(provide, BEMDOM) {
 
                     this.domElem[0].addEventListener('change', function(e){
                         this._bDemo.changeEngine(e.target.value);
+                        this._bDemo.save();
                     }.bind(this));
                 }
             }
+        },
+
+        setValue: function(value) {
+            this.domElem.val(value).trigger('change');
+        },
+
+        getValue: function() {
+            return this.domElem.val();
         }
     }, {}));
 

--- a/common.blocks/version-selector/version-selector.bemhtml.js
+++ b/common.blocks/version-selector/version-selector.bemhtml.js
@@ -3,7 +3,8 @@ block('version-selector')(
 
     js()(function() {
         return {
-            default: this.ctx.versions[0]
+            default: this.ctx.versions[0],
+            versions: this.ctx.versions
         };
     }),
 
@@ -11,7 +12,7 @@ block('version-selector')(
         return this.ctx.versions.map(function(item) {
             return {
                 tag: 'option',
-                attrs: { value: item.hash },
+                attrs: { value: item.name },
                 content: item.name
             };
         });

--- a/common.blocks/version-selector/version-selector.js
+++ b/common.blocks/version-selector/version-selector.js
@@ -27,8 +27,8 @@ modules.define('version-selector', [ 'i-bem__dom', 'querystring' ], function(pro
                     };
 
                     select.domElem.on('change', function(e) {
-                        var name = e.target.value;
-                        var hash = select._getHashByVersion(name);
+                        var version = e.target.value;
+                        var hash = select.params.versions.find(function(item) { return item.name === version; }).hash;
                         var freeze = function() {
                                 transport && d.getElementById(TRANSPORT_ID).remove();
                                 var demo = document.getElementsByClassName('demo')[0];
@@ -71,16 +71,6 @@ modules.define('version-selector', [ 'i-bem__dom', 'querystring' ], function(pro
 
         getValue: function() {
             return this.domElem.val();
-        },
-
-        _getHashByVersion: function(version) {
-            var item = this.params.versions.find(function(item) {
-                return item.name === version;
-            });
-            if (item) {
-                return item.hash;
-            }
-            return null;
         }
     }, {}));
 

--- a/common.blocks/version-selector/version-selector.js
+++ b/common.blocks/version-selector/version-selector.js
@@ -14,11 +14,10 @@ modules.define('version-selector', [ 'i-bem__dom', 'querystring' ], function(pro
                     var URL = 'https://rawgit.com/miripiruni/bem-xjst/';
                     var FILE = '/xindex.browser.bemhtml.js';
                     var TRANSPORT_ID = 'transport';
-                    var select = d.getElementsByClassName('version-selector')[0];
+                    var select = this;
 
                     window.onpopstate = function(event) {
                         var ver = encodeURIComponent(qs.parse(location.href).bemxjst_version || '');
-                        var select = d.getElementsByClassName('version-selector')[0];
 
                         if (!ver) {
                             ver = JSON.parse(select.dataset.bem);
@@ -28,7 +27,7 @@ modules.define('version-selector', [ 'i-bem__dom', 'querystring' ], function(pro
                         select.value = ver;
                     };
 
-                    select.onchange = function onVersionChange(e) {
+                    select.domElem.on('change', function(e) {
                         var val = e.target.value;
                         var parseParams = function parseParams(params) {
                                 var ret = {},
@@ -75,24 +74,20 @@ modules.define('version-selector', [ 'i-bem__dom', 'querystring' ], function(pro
                             console.error('Unable to load ' + this.src);
                             unfreeze();
                         };
-
-                        var params = parseParams(location.search.replace('?', ''));
-                        // TODO (miripiruni): params.version = this.selectedOptions[0].innerText;
-                        params.toString = function() {
-                            var params = this;
-
-                            return Object.keys(this)
-                                .filter(function(p) { return p !== 'toString'; })
-                                .map(function(p) {
-                                    return p + '=' + encodeURIComponent(params[p]);
-                                }).join('&');
-                        };
-
-                        history.pushState({}, d.title, location.pathname + '?' + params.toString());
-                    };
-
+                        bDemo.save();
+                    });
+                    this.emit('ready');
                 }
             }
+        },
+
+        setValue: function(value) {
+            this.domElem.val(value).trigger('change');
+            return this;
+        },
+
+        getValue: function() {
+            return this.domElem.val();
         }
     }, {}));
 

--- a/common.blocks/version-selector/version-selector.js
+++ b/common.blocks/version-selector/version-selector.js
@@ -29,24 +29,7 @@ modules.define('version-selector', [ 'i-bem__dom', 'querystring' ], function(pro
 
                     select.domElem.on('change', function(e) {
                         var val = e.target.value;
-                        var parseParams = function parseParams(params) {
-                                var ret = {},
-                                    hash,
-                                    hashes = params && params.split('&');
-
-                                if (!params) {
-                                    return;
-                                }
-
-                                for (var i = 0; i < hashes.length; i++) {
-                                    hash = hashes[i].split('=');
-                                    // Allow plus sign as a space
-                                    ret[hash[0]] = decodeURIComponent(hash[1].replace(/\+/g, ' '));
-                                }
-
-                                return ret;
-                            },
-                            freeze = function() {
+                        var freeze = function() {
                                 transport && d.getElementById(TRANSPORT_ID).remove();
                                 var demo = document.getElementsByClassName('demo')[0];
                                 demo.classList.remove('demo_state_loaded');

--- a/common.blocks/version-selector/version-selector.js
+++ b/common.blocks/version-selector/version-selector.js
@@ -17,14 +17,14 @@ modules.define('version-selector', [ 'i-bem__dom', 'querystring' ], function(pro
                     var select = this;
 
                     window.onpopstate = function(event) {
-                        var ver = encodeURIComponent(qs.parse(location.href).bemxjst_version || '');
+                        var ver = encodeURIComponent(qs.parse(location.href).version || '');
 
                         if (!ver) {
                             ver = JSON.parse(select.dataset.bem);
                             ver = ver['version-selector'].default.hash;
                         }
 
-                        select.value = ver;
+                        select.setValue(ver);
                     };
 
                     select.domElem.on('change', function(e) {

--- a/common.blocks/version-selector/version-selector.js
+++ b/common.blocks/version-selector/version-selector.js
@@ -20,15 +20,15 @@ modules.define('version-selector', [ 'i-bem__dom', 'querystring' ], function(pro
                         var ver = encodeURIComponent(qs.parse(location.href).version || '');
 
                         if (!ver) {
-                            ver = JSON.parse(select.dataset.bem);
-                            ver = ver['version-selector'].default.hash;
+                            ver = select.params.default.name;
                         }
 
                         select.setValue(ver);
                     };
 
                     select.domElem.on('change', function(e) {
-                        var val = e.target.value;
+                        var name = e.target.value;
+                        var hash = select._getHashByVersion(name);
                         var freeze = function() {
                                 transport && d.getElementById(TRANSPORT_ID).remove();
                                 var demo = document.getElementsByClassName('demo')[0];
@@ -46,7 +46,7 @@ modules.define('version-selector', [ 'i-bem__dom', 'querystring' ], function(pro
 
                         transport = d.createElement('script');
                         transport.id = TRANSPORT_ID;
-                        transport.src = URL + val + FILE;
+                        transport.src = URL + hash + FILE;
                         d.body.appendChild(transport);
 
                         transport.onload = function() {
@@ -71,6 +71,16 @@ modules.define('version-selector', [ 'i-bem__dom', 'querystring' ], function(pro
 
         getValue: function() {
             return this.domElem.val();
+        },
+
+        _getHashByVersion: function(version) {
+            var item = this.params.versions.find(function(item) {
+                return item.name === version;
+            });
+            if (item) {
+                return item.hash;
+            }
+            return null;
         }
     }, {}));
 

--- a/desktop.bundles/index/index.bemjson.js
+++ b/desktop.bundles/index/index.bemjson.js
@@ -1,4 +1,5 @@
 var package = require('../../package.json'),
+    BEMXJST_VERSION = package.version,
     GITHUB_URL = package.repository.url,
     fs = require('fs'),
     defaults = {
@@ -108,6 +109,9 @@ module.exports = {
         },
         {
             block: 'demo',
+            js: {
+                version: BEMXJST_VERSION
+            },
             mods: { state: 'loading' },
             content: [
                 {

--- a/desktop.bundles/index/index.bemjson.js
+++ b/desktop.bundles/index/index.bemjson.js
@@ -1,5 +1,4 @@
 var package = require('../../package.json'),
-    BEMXJST_VERSION = package.version,
     GITHUB_URL = package.repository.url,
     fs = require('fs'),
     defaults = {
@@ -9,14 +8,13 @@ var package = require('../../package.json'),
 
 module.exports = {
     block: 'page',
-    title: 'BEM-XJST ' + BEMXJST_VERSION + ' Demo',
+    title: 'BEM-XJST Demo',
     head: [
         { elem: 'meta', attrs: { name: 'viewport', content: 'width=device-width, initial-scale=1' } },
         { elem: 'css', url: 'xindex.css' }
     ],
     scripts: [
         { elem: 'js', url: 'xindex.js' },
-        { elem: 'js', url: 'xindex.browser.bemhtml.js' },
         { elem: 'js', url: 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.2/ace.js' },
         { elem: 'js', url: 'https://apis.google.com/js/client.js' }
     ],
@@ -110,9 +108,6 @@ module.exports = {
         },
         {
             block: 'demo',
-            js: {
-                version: BEMXJST_VERSION + '_3' // инвалидация дефолтных значений
-            },
             mods: { state: 'loading' },
             content: [
                 {


### PR DESCRIPTION
Fixes #389 

### Changes proposed in this pull request

- drops load the default `xbrowser.bemhtml.js` bundle during the page load: now it loads dynamically corresponding to value from engine select (the last version is default, so nothing's changed here)
- `version` and `engine` into URL, saved on every select change

### Problems

I've encountered a problem. You can face it if change version below 8.4.0, pick BEMTREE and reload the page: `this._engine is not define` instead of rendered bemjson from the bemtree template.

**Why this happens**

The bundle actually doesn't have `BEMTREE` as a global object, so when you change the version within select in runtime everything is okay, because you actually use `BEMTREE` **from the old bunlde**. In current production the first bundle (version 8.5.2) loads every time, so you can't see the effect.

I'm not sure how to deal with it, let's discuss it :)