### PR TITLE
Class builder: mod val delimeter

### DIFF
--- a/docs/en/3-api.md
+++ b/docs/en/3-api.md
@@ -128,7 +128,7 @@ var templates = bemxjst.bemhtml.compile(function() {
         // Setting up BEM naming
         naming: {
             elem: '__',
-            mod: '_'
+            mod: { name: '--', val: '_' }
         }
     });
 
@@ -147,7 +147,7 @@ var html = templates.apply(bemjson);
 The resulting `html` contains the string:
 
 ```html
-<div class="page page_theme_gray"><div class="page__head page__head_type_short"></div></div>
+<div class="page page--theme_gray"><div class="page__head page__head--type_short"></div></div>
 ```
 
 You can find more information in [naming conventions](https://en.bem.info/methodology/naming-convention/) article.

--- a/docs/ru/3-api.md
+++ b/docs/ru/3-api.md
@@ -127,7 +127,7 @@ var templates = bemxjst.bemhtml.compile(function() {
         // Настройка БЭМ-нейминга
         naming: {
             elem: '__',
-            mod: '_'
+            mod: { name: '--', val: '_' }
         }
     });
 
@@ -146,8 +146,8 @@ var html = templates.apply(bemjson);
 В результате `html` будет содержать строку:
 
 ```html
-<div class="page page_theme_gray">
-    <div class="page__head page__head_type_short"></div>
+<div class="page page--theme_gray">
+    <div class="page__head page__head--type_short"></div>
 </div>
 ```
 

--- a/lib/bemxjst/class-builder.js
+++ b/lib/bemxjst/class-builder.js
@@ -1,7 +1,17 @@
 function ClassBuilder(options) {
-  this.modDelim = options.mod || '_';
   this.elemDelim = options.elem || '__';
+
+  this.modDelim = typeof options.mod === 'string' ?
+    {
+      name: options.mod || '_',
+      val: options.mod || '_'
+    } :
+    {
+      name: options.mod && options.mod.name || '_',
+      val: options.mod && options.mod.val || '_'
+    };
 }
+
 exports.ClassBuilder = ClassBuilder;
 
 ClassBuilder.prototype.build = function(block, elem) {
@@ -12,8 +22,8 @@ ClassBuilder.prototype.build = function(block, elem) {
 };
 
 ClassBuilder.prototype.buildModPostfix = function(modName, modVal) {
-  var res = this.modDelim + modName;
-  if (modVal !== true) res += this.modDelim + modVal;
+  var res = this.modDelim.name + modName;
+  if (modVal !== true) res += this.modDelim.val + modVal;
   return res;
 };
 

--- a/test/custom-naming-test.js
+++ b/test/custom-naming-test.js
@@ -29,4 +29,21 @@ describe('Custom delimeters for BEM naming', function() {
       }
     });
   });
+
+  it('should support custom naming ' +
+    'for modName and modVal delimeters', function() {
+    test(function() {
+    }, [
+      {
+        block: 'b1',
+        elem: 'e1',
+        elemMods: { a: 'b' }
+      }
+    ], '<div class="b1__e1 b1__e1--a_b"></div>', {
+      naming: {
+        elem: '__',
+        mod: { name: '--', val: '_' }
+      }
+    });
+  });
 });


### PR DESCRIPTION
Fixes #469 

Now `naming` option can be:

1) {String}.
2) {Object}: `{name: '…', val: '_' }`.

Default value of naming wasn’t changed. Backward capability is supported.

cc @zxqfox 