### PR TITLE
BEMHTML: fix compiler for module.exports

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -186,7 +186,7 @@ Compiler.prototype.generate = function generate(code, options) {
         }).join('')
       ) : (
         exportName + '= buildBemXjst(this.global);' +
-        'global["' + exportName + '"] = ' + exportName + ';'
+        'exp["' + exportName + '"] = ' + exportName + ';'
       ) : '',
 
     '})(typeof window !== "undefined" ? ' +


### PR DESCRIPTION
Fixes 
BEMHTML generate bug - do not exports to commonJS
