### PR TITLE
bem-xjst: isolate input bemjson (fix for #495)

### DIFF
--- a/lib/bemxjst/index.js
+++ b/lib/bemxjst/index.js
@@ -537,7 +537,17 @@ BEMXJST.prototype.exportApply = function(exports) {
   var ret = exports || {};
 
   ret.apply = function(context) {
-    return self.run(context);
+    var arg;
+    if (Array.isArray(context)) {
+      arg = [].concat(context);
+    } else if (context === null) {
+      arg = null;
+    } else if (typeof context === 'object') {
+      arg = utils.extend({}, context);
+    } else {
+      arg = context;
+    }
+    return self.run(arg);
   };
 
   // Add templates at run time

--- a/test/modes-extend-test.js
+++ b/test/modes-extend-test.js
@@ -81,4 +81,24 @@ describe('Modes extend', function() {
     }, { block: 'b', foo: 'This is' },
     '<div class="b">This is ContextChild</div>');
   });
+
+  it('should work with several apply() calls', function() {
+    var bemjson = { block: 'b1' };
+    var expected = '<div class="b1">42</div>';
+    var tmpl = fixtures.compile(function() {
+      block('b1').extend()({ 'ctx.content': 42 });
+    });
+
+    assert.equal(
+      tmpl.apply(bemjson),
+      expected,
+      'first apply() call returns not expected value'
+    );
+
+    assert.equal(
+      tmpl.apply(bemjson),
+      expected,
+      'first apply() call returns not expected value'
+    );
+  });
 });

--- a/test/modes-wrap-test.js
+++ b/test/modes-wrap-test.js
@@ -58,6 +58,30 @@ describe('Modes wrap', function() {
     }, { block: 'b1' }, '<div class="b1"></div>');
   });
 
+  it('should work with several apply() calls', function() {
+    var bemjson = { block: 'b1' };
+    var expected = '<div class="b2"><div class="b1"></div></div>';
+    var tmpl = fixtures.compile(function() {
+      block('b1').wrap()(function() {
+        return {
+          block: 'b2',
+          content: this.ctx
+        };
+      });
+    });
+
+    assert.equal(
+      tmpl.apply(bemjson),
+      expected,
+      'first apply() call returns not expected value'
+    );
+
+    assert.equal(
+      tmpl.apply(bemjson),
+      expected,
+      'first apply() call returns not expected value'
+    );
+  });
 
   it('should use current context (with simple value)', function() {
     test(function() {


### PR DESCRIPTION
Fixes #495

### Changes proposed in this pull request

On every `templates.apply(bemjson)` call we can use copy of `bemjson`, not the `bemjson` by link.

### Checklist

 - [x] Tests added
 - [ ] Benchmark checked


@tadatuta if it look like production decition for you, I can run benchmarks.