### PR TITLE
Single quotes for data-attrs

### DIFF
--- a/lib/bemhtml/index.js
+++ b/lib/bemhtml/index.js
@@ -171,9 +171,14 @@ BEMHTML.prototype.renderAttrs = function(attrs) {
         var attrVal = utils.isSimple(attr) ? attr : this.run(attr);
         out += ' ' + name + '=';
 
-        out += this._unquotedAttrs && utils.isUnquotedAttr(attrVal) ?
-          attrVal :
-          ('"' + utils.attrEscape(attrVal) + '"');
+        // data-attr
+        if (name.indexOf('data-') === 0) {
+          out += '\'' + utils.jsAttrEscape(attrVal) + '\'';
+        } else {
+          out += this._unquotedAttrs && utils.isUnquotedAttr(attrVal) ?
+            attrVal :
+            ('"' + utils.attrEscape(attrVal) + '"');
+        }
       }
     }
   }

--- a/test/templates-syntax-test.js
+++ b/test/templates-syntax-test.js
@@ -369,7 +369,7 @@ describe('Templates syntax', function() {
             });
           },
           { block: 'b', attrs: { 'data-test': 'one-two' } },
-          '<div class="b" data-test="one-two" ' +
+          '<div class="b" data-test=\'one-two\' ' +
             'mix="doesnt-work-as-mix-for-block-b"></div>');
       });
 


### PR DESCRIPTION
### Changes proposed in this pull request
- escape `data-attrs` with single quote instead of double quotes.

Before:
```
<script data-rum-counter-init="{&quot;settings&quot;:{&quot;slots&quot;:[[&quot;34317&quot;,&quot;0&quot;,&quot;92&quot;]],&quot;reqid&quot;:&quot;1519558173382417-430883477828628736899412-sas1-1734&quot;},&quot;vars&quot;:{&quot;143&quot;:&quot;28.2719.584&quot;,&quot;287&quot;:116998}}"
```

After:
```
<script data-rum-counter-init='{"settings":{"slots":[["40173","0","6"]],"reqid":"1519558245549626-1395428883362319826026852-vla1-2547"},"vars":{"143":"28.2719.584","287":213}}' >
```

It makes HTML a much more readable in my opinion.

Benchmark results:
```
sbmaxx@sbmaxx ~/Develop/bem-xjst/bench $ node runner.js --rev1 e75de5a0155f005d068037b882fb11003b1bdeb8  --rev2 85824a090fe97b46393b1a6bc5c437a954abddc4 --bemjson 1000
Test started…
{ _: [],
  h: false,
  help: false,
  rev1: 'e75de5a0155f005d068037b882fb11003b1bdeb8',
  rev2: '85824a090fe97b46393b1a6bc5c437a954abddc4',
  bemjson: 1000,
  '$0': 'runner.js',
  repeat: undefined,
  verbose: undefined,
  dataPath: undefined,
  templatePath: undefined }
2018-02-25T12:09:36.763Z
Total test time:  20081.514727
./lib/compare.py ./dat-e75de-85824 ./dat-e75de-85824/85824a090fe97b46393b1a6bc5c437a954abddc4-1000-1519560596842.dat ./dat-e75de-85824/e75de5a0155f005d068037b882fb11003b1bdeb8-1000-1519560587011.dat
Percentile:  0.5
{ rev1: 5.612971,
  rev2: 5.45215,
  'diff abs': 0.16082100000000032,
  'diff percent': 2.865167128068191 }

Percentile:  0.9
{ rev1: 8.551933,
  rev2: 8.584497,
  'diff abs': 0.032564000000000703,
  'diff percent': 0.3793349802556967 }

Percentile:  0.95
{ rev1: 10.277574,
  rev2: 10.161723,
  'diff abs': 0.11585099999999926,
  'diff percent': 1.1272212683654637 }
```

### Checklist

 - [ ] Documentation changed
 - [x] Tests added
 - [x] Benchmark checked


### Benchmark result
