### PR TITLE
Single quotes in js attrs

### DIFF
--- a/docs/en/3-api.md
+++ b/docs/en/3-api.md
@@ -8,6 +8,7 @@
   - [XHTML option](#xhtml-option)
   - [Optional End Tags](#optional-end-tags)
   - [Unquoted attributes](#unquoted-attributes)
+  - [singleQuotesForDataAttrs option](#singlequotesfordataattrs-option)
   - [Escaping](#escaping)
   - [Runtime linting](#runtime-linting)
   - [Production mode](#production-mode)
@@ -285,6 +286,52 @@ var html = templates.apply(bemjson);
 
 ```html
 <div class=b name=test></div>
+```
+
+### singleQuotesForDataAttrs option
+
+By default data-attributes values will be marked with double quotes. For BEMJSON:
+
+```js
+{
+  block: 'b',
+  attrs: {
+    id: 'without-changes',
+    'data-test': '{"reqid":"42"}'
+  }
+}
+```
+
+*Result of templating:*
+
+```html
+<div class="b" id="without-changes" data-test="{&quot;reqid&quot;:&quot;42&quot;}"></div>
+```
+
+All double quotes inside `data-test` value was escaped. If you want to avoid such behaviour you can use `singleQuotesForDataAttrs` option.
+
+```js
+var bemxjst = require('bem-xjst');
+var templates = bemxjst.bemhtml.compile(() => {
+    // In this example we will add no templates.
+    // Default behaviour is used for HTML rendering.
+    }, {
+        // use single quotes for data-* attributes
+        singleQuotesForDataAttrs: true
+    });
+
+var bemjson = { block: 'b', attrs: {
+  id: 'without-changes',
+  'data-test': '{"reqid":"42"}'
+} };
+
+var html = templates.apply(bemjson);
+```
+
+*Result of templating with option:*
+
+```html
+<div class="b" id="without-changes" data-test='{"reqid":"42"}'></div>
 ```
 
 ### Escaping

--- a/docs/ru/3-api.md
+++ b/docs/ru/3-api.md
@@ -284,6 +284,52 @@ var html = templates.apply(bemjson);
 <div class=b name=test></div>
 ```
 
+### data-атрибуты с одиночными кавычками
+
+По умолчанию значение data-атрибутов заключено в двойные кавычки. Например, для данных:
+
+```js
+{
+  block: 'b',
+  attrs: {
+    id: 'without-changes',
+    'data-test': '{"reqid":"42"}'
+  }
+}
+```
+
+*Результат шаблонизации по умолчанию будет:*
+
+```html
+<div class="b" id="without-changes" data-test="{&quot;reqid&quot;:&quot;42&quot;}"></div>
+```
+
+Это приводит к экранированию всех двойных кавычек внутри атрибута. Это может быть неудобно при шаблонизации JSON-данных в data-атрибут. Опция `singleQuotesForDataAttrs` указывает что для data-аттрибутов будет использоваться одиночная кавычка, а двойные не нужно экранировать.
+
+```js
+var bemxjst = require('bem-xjst');
+var templates = bemxjst.bemhtml.compile(() => {
+    // В этом примере мы не добавляем пользовательских шаблонов.
+        // Для рендеринга HTML будет использовано поведение шаблонизатора по умолчанию.
+        }, {
+        // использовать одиночные кавычки для data-атрибутов
+        singleQuotesForDataAttrs: true
+    });
+
+var bemjson = { block: 'b', attrs: {
+  id: 'without-changes',
+  'data-test': '{"reqid":"42"}'
+} };
+
+var html = templates.apply(bemjson);
+```
+
+*Результат шаблонизации с опцией будет:*
+
+```html
+<div class="b" id="without-changes" data-test='{"reqid":"42"}'></div>
+```
+
 ### Экранирование
 
 Вы можете включить экранирование содержимого поля `content` опцией `escapeContent`. В этом случае ко всем строковым значениям `content` будет применена функция [`xmlEscape`](6-templates-context.md#xmlescape).

--- a/lib/bemhtml/index.js
+++ b/lib/bemhtml/index.js
@@ -11,6 +11,10 @@ function BEMHTML(options) {
 
   this._elemJsInstances = options.elemJsInstances;
   this._omitOptionalEndTags = options.omitOptionalEndTags;
+  this._singleQuotesForDataAttrs =
+    typeof options.singleQuotesForDataAttrs === 'undefined' ?
+      false :
+      options.singleQuotesForDataAttrs;
   this._unquotedAttrs = typeof options.unquotedAttrs === 'undefined' ?
     false :
     options.unquotedAttrs;
@@ -170,20 +174,20 @@ BEMHTML.prototype.renderAttrs = function(attrs) {
       } else {
         var attrVal = utils.isSimple(attr) ? attr : this.run(attr);
         out += ' ' + name + '=';
-
-        // data-attr
-        if (name.indexOf('data-') === 0) {
-          out += '\'' + utils.jsAttrEscape(attrVal) + '\'';
-        } else {
-          out += this._unquotedAttrs && utils.isUnquotedAttr(attrVal) ?
-            attrVal :
-            ('"' + utils.attrEscape(attrVal) + '"');
-        }
+        out += (this._singleQuotesForDataAttrs && name.indexOf('data-') === 0) ?
+          '\'' + utils.jsAttrEscape(attrVal) + '\'' :
+          this.getAttrValue(attrVal);
       }
     }
   }
 
   return out;
+};
+
+BEMHTML.prototype.getAttrValue = function(attrVal) {
+  return this._unquotedAttrs && utils.isUnquotedAttr(attrVal) ?
+    attrVal :
+    ('"' + utils.attrEscape(attrVal) + '"');
 };
 
 BEMHTML.prototype.renderMix = function(entity, mix, jsParams, addJSInitClass) {

--- a/lib/bemhtml/index.js
+++ b/lib/bemhtml/index.js
@@ -171,9 +171,14 @@ BEMHTML.prototype.renderAttrs = function(attrs) {
         var attrVal = utils.isSimple(attr) ? attr : this.run(attr);
         out += ' ' + name + '=';
 
-        out += this._unquotedAttrs && utils.isUnquotedAttr(attrVal) ?
-          attrVal :
-          ('"' + utils.attrEscape(attrVal) + '"');
+        // data-attr
+        if (name.indexOf('data-') === 0) {
+          out += '\'' + utils.jsAttrEscape(attrVal) + '\'';
+        } else {
+          out += this._unquotedAttrs && utils.isUnquotedAttr(attrVal) ?
+            attrVal :
+            ('"' + utils.attrEscape(attrVal) + '"');
+        }
       }
     }
   }

--- a/test/bemhtml-test.js
+++ b/test/bemhtml-test.js
@@ -211,4 +211,29 @@ describe('BEMHTML engine tests', function() {
         { unquotedAttrs: true });
     });
   });
+
+  describe('singleQuotesForDataAttrs option', function() {
+    it('should render data-attr value using double quotes by default',
+    function() {
+      test(function() {},
+        { block: 'b', attrs: {
+          id: 'without-changes',
+          'data-test': '{"reqid":"42"}'
+        } },
+        '<div class="b" id="without-changes" ' +
+        'data-test="{&quot;reqid&quot;:&quot;42&quot;}"></div>');
+    });
+
+    it('should render data-attr value using single quotes if option true',
+    function() {
+      test(function() {},
+        { block: 'b', attrs: {
+          id: 'without-changes',
+          'data-test': '{"reqid":"42"}'
+        } },
+        '<div class="b" id="without-changes" ' +
+        'data-test=\'{"reqid":"42"}\'></div>',
+        { singleQuotesForDataAttrs: true });
+    });
+  });
 });

--- a/test/templates-syntax-test.js
+++ b/test/templates-syntax-test.js
@@ -369,7 +369,7 @@ describe('Templates syntax', function() {
             });
           },
           { block: 'b', attrs: { 'data-test': 'one-two' } },
-          '<div class="b" data-test="one-two" ' +
+          '<div class="b" data-test=\'one-two\' ' +
             'mix="doesnt-work-as-mix-for-block-b"></div>');
       });
 

--- a/test/templates-syntax-test.js
+++ b/test/templates-syntax-test.js
@@ -369,7 +369,7 @@ describe('Templates syntax', function() {
             });
           },
           { block: 'b', attrs: { 'data-test': 'one-two' } },
-          '<div class="b" data-test=\'one-two\' ' +
+          '<div class="b" data-test="one-two" ' +
             'mix="doesnt-work-as-mix-for-block-b"></div>');
       });
 


### PR DESCRIPTION
Fixes #504

### Changes proposed in this pull request

New option `singleQuotesForDataAttrs`.

By default data-attributes values will be marked with double quotes. For BEMJSON:

```js
{
  block: 'b',
  attrs: {
    id: 'without-changes',
    'data-test': '{"reqid":"42"}'
  }
}
```

*Result of templating:*

```html
<div class="b" id="without-changes" data-test="{&quot;reqid&quot;:&quot;42&quot;}"></div>
```

All double quotes inside `data-test` value was escaped. If you want to avoid such behaviour you can use `singleQuotesForDataAttrs` option.

```js
var bemxjst = require('bem-xjst');
var templates = bemxjst.bemhtml.compile(() => {
    // In this example we will add no templates.
    // Default behaviour is used for HTML rendering.
    }, {
        // use single quotes for data-* attributes
        singleQuotesForDataAttrs: true
    });

var bemjson = { block: 'b', attrs: {
  id: 'without-changes',
  'data-test': '{"reqid":"42"}'
} };

var html = templates.apply(bemjson);
```

*Result of templating with option:*

```html
<div class="b" id="without-changes" data-test='{"reqid":"42"}'></div>
```

### Checklist

 - [x] Documentation changed
 - [x] Tests added
 - [x] Benchmark checked


### Benchmark result

```
miripiruni-osx:bench miripiruni$ rm -fr dat-0c15b-4ee9b && node runner.js --rev1 0c15b96ddcd899eb861e633d68432770b73c47b8 --rev2 4ee9bbd2059c6e8dc6627785e591bf9fa3a27a06  --bemjson 2000 --dataPath ~/Documents/www/web-data/data --templatePath ./template-8x.js
Test started…
{ _: [],
  h: false,
  help: false,
  rev1: '0c15b96ddcd899eb861e633d68432770b73c47b8',
  rev2: '4ee9bbd2059c6e8dc6627785e591bf9fa3a27a06',
  bemjson: 2000,
  dataPath: '/Users/miripiruni/Documents/www/web-data/data',
  templatePath: './template-8x.js',
  '$0': 'runner.js',
  repeat: undefined,
  verbose: undefined }
2018-04-09T14:27:54.695Z
Total test time:  29056.104578
./lib/compare.py ./dat-0c15b-4ee9b ./dat-0c15b-4ee9b/0c15b96ddcd899eb861e633d68432770b73c47b8-2000-1523284089260.dat ./dat-0c15b-4ee9b/4ee9bbd2059c6e8dc6627785e591bf9fa3a27a06-2000-1523284103744.dat
Percentile:  0.5
{ rev1: 4.170607,
  rev2: 4.148633,
  'diff abs': 0.02197400000000016,
  'diff percent': 0.5268777422567039 }

Percentile:  0.9
{ rev1: 6.28738,
  rev2: 6.243454,
  'diff abs': 0.04392599999999991,
  'diff percent': 0.6986375883118234 }

Percentile:  0.95
{ rev1: 7.04883,
  rev2: 7.197721,
  'diff abs': 0.14889099999999988,
  'diff percent': 2.068585320270122 }
```

The result within measurement error. Looks like no speed degradation.