### PR TITLE
package.json: prepublish -> prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bem-xjst": "bin/bem-xjst"
   },
   "scripts": {
-    "prepublish": "npm run make",
+    "prepare": "npm run make",
     "preversion": "bash scripts/update-authors.sh && git add AUTHORS && git commit -m \"update AUTHORS\" || true",
     "make": "npm run make:bemhtml && npm run make:bemtree",
     "make:bemhtml": "browserify --standalone bemhtml lib/bemhtml/index.js -o lib/bemhtml/bundle.js",


### PR DESCRIPTION
```
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```