### PR TITLE
renderMix: transform nestedMix to the single-item array if it's not array

### DIFF
--- a/lib/bemhtml/index.js
+++ b/lib/bemhtml/index.js
@@ -273,6 +273,10 @@ BEMHTML.prototype.renderMix = function(entity, mix, jsParams, addJSInitClass) {
     if (!nestedMix)
       continue;
 
+    // Transform nestedMix to the single-item array if it's not array
+    if (!Array.isArray(nestedMix))
+      nestedMix = [ nestedMix ];
+
     for (var j = 0; j < nestedMix.length; j++) {
       var nestedItem = nestedMix[j];
       if (!nestedItem) continue;


### PR DESCRIPTION
### Changes proposed in this pull request

- FIX: renderMix: transform nestedMix to the single-item array if it's not an array

### Checklist

 - [ ] Documentation changed
 - [ ] Tests added
 - [ ] Benchmark checked


### Benchmark result
