### PR TITLE
package.json: Update enb-source-map

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "coa": "^1.0.1",
-    "enb-source-map": "1.12.0",
+    "enb-source-map": "1.12.1",
     "inherits": "^2.0.1",
     "q": "^2.0.3"
   },


### PR DESCRIPTION
Бот гитхаба ругается:

`
bem-xjst@8.9.6 requires atob@2.0.3 via enb-source-map@1.12.0
`
